### PR TITLE
fixed dev doc page body should span the full height

### DIFF
--- a/docs/src/pages/PageContent.tsx
+++ b/docs/src/pages/PageContent.tsx
@@ -26,7 +26,7 @@ export const PageContent: React.FC<PageContentProps> = (props): React.JSX.Elemen
                 display: 'flex',
                 justifyContent: 'center',
                 backgroundColor: theme.vars.palette.background.paper,
-                minHeight: '100vh',
+                height: '100vh',
             }}
         >
             <Box

--- a/docs/src/pages/PageContent.tsx
+++ b/docs/src/pages/PageContent.tsx
@@ -26,7 +26,7 @@ export const PageContent: React.FC<PageContentProps> = (props): React.JSX.Elemen
                 display: 'flex',
                 justifyContent: 'center',
                 backgroundColor: theme.vars.palette.background.paper,
-                height: '100vh',
+                minHeight: '100vh',
             }}
         >
             <Box

--- a/docs/src/pages/PageContent.tsx
+++ b/docs/src/pages/PageContent.tsx
@@ -21,7 +21,14 @@ export const PageContent: React.FC<PageContentProps> = (props): React.JSX.Elemen
     }, [wideLayout]);
 
     return (
-        <Box sx={{ display: 'flex', justifyContent: 'center', backgroundColor: theme.vars.palette.background.paper }}>
+        <Box
+            sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                backgroundColor: theme.vars.palette.background.paper,
+                minHeight: '100vh',
+            }}
+        >
             <Box
                 sx={{
                     width: '100%',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react/issues/52 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:
<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-
Before 
<img width="3452" height="1918" alt="image" src="https://github.com/user-attachments/assets/a19d8815-4d0b-49d6-a1cd-5d8ff04e7e0d" />

After  fix

<img width="3454" height="1938" alt="image" src="https://github.com/user-attachments/assets/4e53e866-42d5-4711-adad-ec8d5fb803cc" />


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Go to Workflows Overview section check  overview page span the full height now.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [x] Code passes all linting checks
- [x] All tests pass
- [x] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] Changelog has been updated (if applicable)
