### PR TITLE
fixed info list item divider

### DIFF
--- a/packages/component-library/CHANGELOG.md
+++ b/packages/component-library/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Theme related style issues. ([#112](https://github.com/etn-ccis/blui-react/issues/112)).
+- Wrong info list item partial divider under right-to-left ([#17](https://github.com/etn-ccis/blui-react/issues/17))
 
 # v8.0.0 (July 28, 2025)
 

--- a/packages/component-library/src/core/InfoListItem/InfoListItemStyledComponents.tsx
+++ b/packages/component-library/src/core/InfoListItem/InfoListItemStyledComponents.tsx
@@ -85,11 +85,11 @@ export const StatusStripe = styled(Box, {
     backgroundColor: statusColor,
 }));
 
-export const InfoListItemDivider = styled(Divider)<Pick<InfoListItemProps, 'divider'>>(({ divider, theme }) => ({
+export const InfoListItemDivider = styled(Divider)<Pick<InfoListItemProps, 'divider'>>(({ divider }) => ({
     position: 'absolute',
     bottom: 0,
-    right: theme.direction === 'rtl' ? (divider === 'full' ? 0 : `4.5rem`) : 0,
-    left: theme.direction === 'ltr' ? (divider === 'full' ? 0 : `4.5rem`) : 0,
+    right: 0,
+    left: divider === 'full' ? 0 : `4.5rem`,
     zIndex: 0,
 }));
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # . [Wrong info list item partial divider under right-to-left](https://github.com/etn-ccis/blui-react/issues/17)

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-
<img width="1342" height="715" alt="Screenshot 2025-11-07 at 11 16 45 AM" src="https://github.com/user-attachments/assets/280195a5-9e3f-4ddd-8f80-4f3365043218" />


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [x] Code passes all linting checks
- [x] All tests pass
- [ ] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [x] Changelog has been updated (if applicable)
