### PR TITLE
Updated color token for component in dark mode

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -17,7 +17,7 @@
         "analyze": "source-map-explorer 'build/static/js/*.js'"
     },
     "dependencies": {
-        "@brightlayer-ui/colors": "^3.1.1",
+        "@brightlayer-ui/colors": "^3.2.0-alpha.1",
         "@brightlayer-ui/icons-mui": "^3.6.0",
         "@brightlayer-ui/react-components": "workspace:^",
         "@brightlayer-ui/react-progress-icons": "^2.1.1",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -39,7 +39,7 @@
         "React"
     ],
     "dependencies": {
-        "@brightlayer-ui/colors": "^3.1.1",
+        "@brightlayer-ui/colors": "^3.2.0-alpha.1",
         "@brightlayer-ui/types": "^2.0.0",
         "@fontsource/open-sans": "^5.0.3",
         "color": "^4.2.3"

--- a/packages/themes/src/blueMergedTheme.ts
+++ b/packages/themes/src/blueMergedTheme.ts
@@ -15,6 +15,8 @@ import MuiCheckbox from './componentStylesOverrides/MuiCheckbox';
 import MuiButtonBase from './componentStylesOverrides/MuiButtonBase';
 import MuiChip from './componentStylesOverrides/MuiChip';
 import MuiDrawer from './componentStylesOverrides/MuiDrawer';
+import MuiMenu from './componentStylesOverrides/MuiMenu';
+import MuiDialog from './componentStylesOverrides/MuiDialog';
 import MuiFab from './componentStylesOverrides/MuiFab';
 import MuiListItem from './componentStylesOverrides/MuiListItem';
 import MuiListSubheader from './componentStylesOverrides/MuiListSubheader';
@@ -86,8 +88,8 @@ const DarkThemeColors = {
         dark: BLUIColors.yellow[900],
     },
     background: {
-        default: BLUIColors.darkBlack[800],
-        paper: BLUIColors.black[900],
+        default: BLUIColors.darkBlack[900],
+        paper: BLUIColors.darkBlack[500],
     },
     text: {
         primary: BLUIColors.black[50],
@@ -137,6 +139,8 @@ export const blueThemes = createTheme({
         MuiButtonBase: MuiButtonBase,
         MuiChip: MuiChip,
         MuiDrawer: MuiDrawer,
+        MuiMenu: MuiMenu,
+        MuiDialog: MuiDialog,
         MuiFab: MuiFab,
         MuiListItem: MuiListItem,
         MuiListSubheader: MuiListSubheader,

--- a/packages/themes/src/componentStylesOverrides/MuiAppBar.ts
+++ b/packages/themes/src/componentStylesOverrides/MuiAppBar.ts
@@ -19,7 +19,7 @@ export default {
         colorPrimary: ({ theme }) => ({
             ...theme.applyStyles('dark', {
                 color: theme.vars.palette.text.primary,
-                backgroundColor: BLUIColors.black[800],
+                backgroundColor: BLUIColors.darkBlack[300],
             }),
         }),
         colorSecondary: ({ theme }) => ({

--- a/packages/themes/src/componentStylesOverrides/MuiDialog.ts
+++ b/packages/themes/src/componentStylesOverrides/MuiDialog.ts
@@ -3,11 +3,10 @@ import * as BLUIColors from '@brightlayer-ui/colors';
 
 export default {
     styleOverrides: {
-        root: ({ theme }) => ({
-            backgroundColor: theme.vars.palette.primary.main,
+        paper: ({ theme }) => ({
             ...theme.applyStyles('dark', {
                 backgroundColor: BLUIColors.darkBlack[300],
             }),
         }),
     },
-} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiBottomNavigation'];
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiDialog'];

--- a/packages/themes/src/componentStylesOverrides/MuiDrawer.ts
+++ b/packages/themes/src/componentStylesOverrides/MuiDrawer.ts
@@ -10,7 +10,7 @@ export default {
         }),
         paperAnchorBottom: ({ theme }) => ({
             ...theme.applyStyles('dark', {
-                backgroundColor: theme.vars.palette.background.paper,
+                backgroundColor: BLUIColors.darkBlack[300],
             }),
         }),
     },

--- a/packages/themes/src/componentStylesOverrides/MuiMenu.ts
+++ b/packages/themes/src/componentStylesOverrides/MuiMenu.ts
@@ -3,11 +3,10 @@ import * as BLUIColors from '@brightlayer-ui/colors';
 
 export default {
     styleOverrides: {
-        root: ({ theme }) => ({
-            backgroundColor: theme.vars.palette.primary.main,
+        paper: ({ theme }) => ({
             ...theme.applyStyles('dark', {
                 backgroundColor: BLUIColors.darkBlack[300],
             }),
         }),
     },
-} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiBottomNavigation'];
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiMenu'];

--- a/packages/themes/src/componentStylesOverrides/MuiTabs.ts
+++ b/packages/themes/src/componentStylesOverrides/MuiTabs.ts
@@ -1,10 +1,12 @@
 import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import * as BLUIColors from '@brightlayer-ui/colors';
 
 export default {
     styleOverrides: {
         root: ({ theme }) => ({
             ...theme.applyStyles('dark', {
                 color: theme.vars.palette.text.secondary,
+                backgroundColor: BLUIColors.darkBlack[300],
             }),
         }),
         indicator: ({ theme }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,8 +404,8 @@ importers:
   apps/showcase:
     dependencies:
       '@brightlayer-ui/colors':
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^3.2.0-alpha.1
+        version: 3.2.0-alpha.1
       '@brightlayer-ui/icons-mui':
         specifier: ^3.6.0
         version: 3.6.1(@mui/icons-material@7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -2157,8 +2157,8 @@ importers:
   packages/themes:
     dependencies:
       '@brightlayer-ui/colors':
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^3.2.0-alpha.1
+        version: 3.2.0-alpha.1
       '@brightlayer-ui/types':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2971,6 +2971,9 @@ packages:
 
   '@brightlayer-ui/colors@3.1.1':
     resolution: {integrity: sha512-fV10E5JDuVGDQ0gCY3pEfDwUo1+lvDFC5pmOAAGpN7YDramS6ggUpJ/LmYavKAudw7FNcaJnPi7tsQWJjvv/7w==}
+
+  '@brightlayer-ui/colors@3.2.0-alpha.1':
+    resolution: {integrity: sha512-rfHdc3syQ0V30JrNObbSWqZYu6k4nSnIhfTXb04O25Tm9AQF0HWjE/dxBUmnRbI0WVWBIlpyhvBxwy9dp8Fo9A==}
 
   '@brightlayer-ui/colors@4.0.0':
     resolution: {integrity: sha512-fF7Ne7cz4yFCzR96HrP1RVBw55s+cWbqYkPallnpmmtYnPwNS/DyAbbHFEnl2bxziq3CvAR2S+D6AnjIeluOZA==}
@@ -10592,8 +10595,8 @@ packages:
   libsodium@0.7.16:
     resolution: {integrity: sha512-3HrzSPuzm6Yt9aTYCDxYEG8x8/6C0+ag655Y7rhhWZM9PT4NpdnbqlzXhGZlDnkgR6MeSTnOt/VIyHLs9aSf+Q==}
 
-  license-checker@git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893:
-    resolution: {commit: d546e3f738e14c62e732346fa355162d46700893, repo: https://github.com/mwittig/license-checker.git, type: git}
+  license-checker@https://codeload.github.com/mwittig/license-checker/tar.gz/d546e3f738e14c62e732346fa355162d46700893:
+    resolution: {tarball: https://codeload.github.com/mwittig/license-checker/tar.gz/d546e3f738e14c62e732346fa355162d46700893}
     version: 1.0.0
     hasBin: true
 
@@ -15864,6 +15867,10 @@ snapshots:
       css-tree: 3.2.1
 
   '@brightlayer-ui/colors@3.1.1':
+    dependencies:
+      '@brightlayer-ui/types': 2.0.0
+
+  '@brightlayer-ui/colors@3.2.0-alpha.1':
     dependencies:
       '@brightlayer-ui/types': 2.0.0
 
@@ -26002,7 +26009,7 @@ snapshots:
 
   libsodium@0.7.16: {}
 
-  license-checker@git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893:
+  license-checker@https://codeload.github.com/mwittig/license-checker/tar.gz/d546e3f738e14c62e732346fa355162d46700893:
     dependencies:
       chalk: 0.5.1
       mkdirp: 0.3.5
@@ -26991,7 +26998,7 @@ snapshots:
       async: 2.6.4
       chalk: 2.4.2
       jquery-extend: 2.0.3
-      license-checker: git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893
+      license-checker: https://codeload.github.com/mwittig/license-checker/tar.gz/d546e3f738e14c62e732346fa355162d46700893
       mkdirp: 0.5.6
       nopt: 3.0.6
       nopt-defaults: 0.0.1


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Changes: https://eaton-corp.atlassian.net/browse/BLUI-7264

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Change in color token for dark mode in  MuiAppBar, MuiNottomNavigation, MuiDialog, MuiDrawer, MuiMenu, MuiTabs
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-
<img width="1728" height="936" alt="Screenshot 2026-05-13 at 6 52 46 PM" src="https://github.com/user-attachments/assets/703adbac-07fd-4e16-8f2f-4e042ae24c3f" />


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- run showcase, then inspect and match background color as per Task-2 https://www.figma.com/design/SkFGxYOHZEwgFaYrmuUfo1/Q2-2026?node-id=740-36238&p=f&m=dev

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [x] Code passes all linting checks
- [x] All tests pass
- [x] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] Changelog has been updated (if applicable)
