### PR TITLE
Added pressed state color for buttons

### DIFF
--- a/packages/themes/CHANGELOG.md
+++ b/packages/themes/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Updated highlight color for hover states of components.
+- Updated pressed state color for buttons.
 
 ### Added
 

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -2,7 +2,7 @@
     "name": "@brightlayer-ui/react-themes",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com>",
     "license": "BSD-3-Clause",
-    "version": "9.1.0-alpha.1",
+    "version": "9.1.0-alpha.2",
     "type": "module",
     "description": "React themes for Brightlayer UI applications",
     "main": "./index.js",

--- a/packages/themes/src/componentStylesOverrides/MuiButton.ts
+++ b/packages/themes/src/componentStylesOverrides/MuiButton.ts
@@ -2,6 +2,8 @@ import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
 import * as BLUIColors from '@brightlayer-ui/colors';
 import Color from 'color';
 
+const DarkPressed = Color(BLUIColors.highlight).alpha(0.36).string();
+
 export default {
     styleOverrides: {
         root: ({ theme }) => ({
@@ -10,6 +12,9 @@ export default {
                 textTransform: 'none',
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
+                },
+                '&:active': {
+                    backgroundColor: DarkPressed,
                 },
             }),
         }),
@@ -40,6 +45,9 @@ export default {
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[100],
+            },
             '&.Mui-disabled': {
                 backgroundColor: theme.vars.palette.background.paper,
                 border: `1px solid ${Color(BLUIColors.black[500]).alpha(0.12).string()}`,
@@ -49,6 +57,9 @@ export default {
                 color: BLUIColors.white[50],
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
+                },
+                '&:active': {
+                    backgroundColor: DarkPressed,
                 },
                 '&.Mui-disabled': {
                     backgroundColor: theme.vars.palette.action.disabledBackground,
@@ -62,6 +73,9 @@ export default {
             '&:hover': {
                 backgroundColor: BLUIColors.blue[300],
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[700],
+            },
             '&.Mui-disabled': {
                 backgroundColor: theme.vars.palette.primary.light,
                 borderWidth: 0,
@@ -72,6 +86,9 @@ export default {
                 color: BLUIColors.white[50],
                 '&:hover': {
                     backgroundColor: BLUIColors.blue[300],
+                },
+                '&:active': {
+                    backgroundColor: BLUIColors.blue[200],
                 },
                 '&.Mui-disabled': {
                     borderWidth: 0,
@@ -86,6 +103,9 @@ export default {
             '&:hover': {
                 backgroundColor: BLUIColors.lightBlue[300],
             },
+            '&:active': {
+                backgroundColor: BLUIColors.lightBlue[500],
+            },
             '&.Mui-disabled': {
                 backgroundColor: theme.vars.palette.primary.light,
                 borderWidth: 0,
@@ -97,6 +117,9 @@ export default {
                 '&:hover': {
                     backgroundColor: BLUIColors.lightBlue[300],
                 },
+                '&:active': {
+                    backgroundColor: BLUIColors.lightBlue[200],
+                },
                 '&.Mui-disabled': {
                     backgroundColor: theme.vars.palette.action.disabledBackground,
                     color: BLUIColors.black[400],
@@ -107,6 +130,9 @@ export default {
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[100],
+            },
             '&.Mui-disabled': {
                 backgroundColor: theme.vars.palette.background.paper,
                 borderColor: Color(BLUIColors.black[500]).alpha(0.12).string(),
@@ -114,6 +140,9 @@ export default {
             ...theme.applyStyles('dark', {
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
+                },
+                '&:active': {
+                    backgroundColor: DarkPressed,
                 },
                 '&.Mui-disabled': {
                     borderColor: Color(BLUIColors.black[300]).alpha(0.36).string(),
@@ -127,6 +156,9 @@ export default {
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[50],
+            },
             '&.Mui-disabled': {
                 backgroundColor: theme.vars.palette.background.paper,
                 borderColor: Color(BLUIColors.black[500]).alpha(0.12).string(),
@@ -135,6 +167,9 @@ export default {
                 borderColor: BLUIColors.black[200],
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
+                },
+                '&:active': {
+                    backgroundColor: DarkPressed,
                 },
                 '&.Mui-disabled': {
                     borderColor: Color(BLUIColors.black[300]).alpha(0.36).string(),
@@ -151,10 +186,16 @@ export default {
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[100],
+            },
             ...theme.applyStyles('dark', {
                 borderColor: theme.vars.palette.primary.main,
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
+                },
+                '&:active': {
+                    backgroundColor: DarkPressed,
                 },
                 '&.Mui-disabled': {
                     borderColor: Color(BLUIColors.black[300]).alpha(0.36).string(),
@@ -171,11 +212,17 @@ export default {
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[100],
+            },
             ...theme.applyStyles('dark', {
                 '&:not(.Mui-disabled)': {
                     borderColor: theme.vars.palette.secondary.main,
                     '&:hover': {
                         backgroundColor: theme.vars.palette.action.hover,
+                    },
+                    '&:active': {
+                        backgroundColor: DarkPressed,
                     },
                 },
                 '&.Mui-disabled': {
@@ -192,6 +239,9 @@ export default {
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[100],
+            },
             ...theme.applyStyles('dark', {
                 '&.Mui-disabled': {
                     color: theme.vars.palette.action.disabled,
@@ -199,15 +249,24 @@ export default {
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
                 },
+                '&:active': {
+                    backgroundColor: DarkPressed,
+                },
             }),
         }),
         textPrimary: ({ theme }) => ({
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[100],
+            },
             ...theme.applyStyles('dark', {
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
+                },
+                '&:active': {
+                    backgroundColor: DarkPressed,
                 },
             }),
         }),
@@ -215,9 +274,15 @@ export default {
             '&:hover': {
                 backgroundColor: theme.vars.palette.action.hover,
             },
+            '&:active': {
+                backgroundColor: BLUIColors.blue[100],
+            },
             ...theme.applyStyles('dark', {
                 '&:hover': {
                     backgroundColor: theme.vars.palette.action.hover,
+                },
+                '&:active': {
+                    backgroundColor: DarkPressed,
                 },
             }),
         }),


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Changed https://eaton-corp.atlassian.net/browse/BLUI-7260

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added pressed state color for buttons
- Updated changelog and package json
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-
<img width="181" height="55" alt="Screenshot 2026-05-22 at 11 36 30 AM" src="https://github.com/user-attachments/assets/496b1602-9225-4486-97af-54cfcab1ae04" />
<img width="181" height="55" alt="Screenshot 2026-05-22 at 11 36 07 AM" src="https://github.com/user-attachments/assets/f06b4cad-b499-4102-97d0-c9b4dbb90e80" />
<img width="181" height="55" alt="Screenshot 2026-05-22 at 11 35 50 AM" src="https://github.com/user-attachments/assets/f0d6e4fa-9f26-48f0-b3f8-11802518b369" />

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- pnpm i
- Run showcase
- check button pressed state for MUI buttons

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [x] Code passes all linting checks
- [x] All tests pass
- [x] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [x] Changelog has been updated (if applicable)
