### PR TITLE
integrated hmi theme sizing to react theme

### DIFF
--- a/apps/showcase/src/index.tsx
+++ b/apps/showcase/src/index.tsx
@@ -14,7 +14,8 @@ import { AppProvider } from './contexts/AppContext';
 import { RTLThemeProvider } from './components/RTLProvider';
 import '@brightlayer-ui/react-themes/open-sans';
 import { ThemeProvider } from '@mui/material';
-import { blueThemes as theme } from '@brightlayer-ui/react-themes';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { blueThemes as theme, HMIThemeProvider } from '@brightlayer-ui/react-themes';
 const container = document.getElementById('root');
 
 const root = createRoot(container!);
@@ -35,12 +36,22 @@ declare global {
 root.render(
     <React.StrictMode>
         <AppProvider>
+            {/* Uncomment this block to test the default BLUI theme */}
+
             <ThemeProvider theme={theme}>
                 <RTLThemeProvider>
                     <CssBaseline />
                     <MainRouter />
                 </RTLThemeProvider>
             </ThemeProvider>
+
+            {/* HMI theme provider (active) */}
+            {/* <HMIThemeProvider size='s'>
+                <RTLThemeProvider>
+                    <CssBaseline />
+                    <MainRouter />
+                </RTLThemeProvider>
+            </HMIThemeProvider> */}
         </AppProvider>
     </React.StrictMode>
 );

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -50,6 +50,7 @@
     "devDependencies": {
         "@mui/material": "^7.1.1",
         "@types/color": "^4.2.0",
+        "@types/react": "^19.2.15",
         "npm-license-crawler": "^0.2.1",
         "tsc-esm-fix": "^3.1.2",
         "typescript": "^5.0.3"

--- a/packages/themes/src/HMIThemeProvider.tsx
+++ b/packages/themes/src/HMIThemeProvider.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { blueThemes } from './hmiBlueMergedTheme';
+import GlobalSizeVariables from './hmiTheme/GlobalSizeVariables';
+
+type HMIThemeProviderProps = {
+    size?: string;
+    mode?: 'light' | 'dark';
+    theme?: object;
+    children: React.ReactNode;
+};
+
+const HMIThemeProvider: React.FC<HMIThemeProviderProps> = ({
+    size = 's',
+    mode = 'light',
+    theme = blueThemes,
+    children,
+}) => (
+    <div data-size={size}>
+        <ThemeProvider key={mode} theme={theme} defaultMode={mode}>
+            <CssBaseline />
+            <GlobalSizeVariables />
+            {children}
+        </ThemeProvider>
+    </div>
+);
+
+export default HMIThemeProvider;

--- a/packages/themes/src/blueColorScheme.ts
+++ b/packages/themes/src/blueColorScheme.ts
@@ -1,0 +1,60 @@
+import { createSimpleLightPalette as createSimplePalette, createSimpleDarkPalette } from './shared';
+import * as BLUIColors from '@brightlayer-ui/colors';
+import Color from 'color';
+
+export const BlueLightThemeColors = {
+    primary: createSimplePalette(BLUIColors.blue),
+    secondary: createSimplePalette(BLUIColors.lightBlue),
+    error: createSimplePalette(BLUIColors.red),
+    success: createSimplePalette(BLUIColors.green),
+    info: createSimplePalette(BLUIColors.lightBlue),
+    divider: Color(BLUIColors.black[500]).alpha(0.12).string(),
+    warning: {
+        light: BLUIColors.yellow[100],
+        main: BLUIColors.yellow[500],
+        dark: BLUIColors.yellow[900],
+    },
+    background: {
+        default: BLUIColors.white[200],
+        paper: BLUIColors.white[50],
+    },
+    text: {
+        primary: BLUIColors.black[500],
+        secondary: BLUIColors.gray[500],
+        hint: BLUIColors.gray[500],
+    },
+    action: {
+        active: BLUIColors.gray[500],
+        disabled: Color(BLUIColors.black[500]).alpha(0.3).string(),
+    },
+};
+
+export const BlueDarkThemeColors = {
+    primary: createSimpleDarkPalette(BLUIColors.blue),
+    secondary: createSimpleDarkPalette(BLUIColors.lightBlue),
+    error: createSimpleDarkPalette(BLUIColors.red),
+    success: createSimpleDarkPalette(BLUIColors.green),
+    info: createSimpleDarkPalette(BLUIColors.lightBlue),
+    divider: Color(BLUIColors.black[200]).alpha(0.36).string(),
+    warning: {
+        light: BLUIColors.yellow[100],
+        main: BLUIColors.yellow[300],
+        dark: BLUIColors.yellow[900],
+    },
+    background: {
+        default: BLUIColors.darkBlack[900],
+        paper: BLUIColors.darkBlack[500],
+    },
+    text: {
+        primary: BLUIColors.black[50],
+        secondary: BLUIColors.black[200],
+        disabled: Color(BLUIColors.black[300]).alpha(0.36).string(),
+        hint: Color(BLUIColors.black[300]).alpha(0.36).string(),
+    },
+    action: {
+        hover: Color(BLUIColors.black[50]).alpha(0.1).string(),
+        active: BLUIColors.black[200],
+        disabled: Color(BLUIColors.black[300]).alpha(0.36).string(),
+        disabledBackground: Color(BLUIColors.black[200]).alpha(0.24).string(),
+    },
+};

--- a/packages/themes/src/blueMergedTheme.ts
+++ b/packages/themes/src/blueMergedTheme.ts
@@ -1,109 +1,50 @@
 import { createTheme } from '@mui/material';
 import type {} from '@mui/material/themeCssVarsAugmentation';
-import { typography, createSimpleLightPalette as createSimplePalette, createSimpleDarkPalette } from './shared';
-import * as BLUIColors from '@brightlayer-ui/colors';
-import Color from 'color';
+import { typography } from './shared';
 import MuiAvatar from './componentStylesOverrides/MuiAvatar';
 import MuiAppBar from './componentStylesOverrides/MuiAppBar';
 import MuiBottomNavigation from './componentStylesOverrides/MuiBottomNavigation';
-import MuiBottomNavigationAction from './componentStylesOverrides/MuiBottomNavigationAction';
-import MuiBadge from './componentStylesOverrides/MuiBadge';
-import MuiBackdrop from './componentStylesOverrides/MuiBackdrop';
 import MuiButton from './componentStylesOverrides/MuiButton';
-import MuiButtonGroup from './componentStylesOverrides/MuiButtonGroup';
-import MuiCheckbox from './componentStylesOverrides/MuiCheckbox';
-import MuiButtonBase from './componentStylesOverrides/MuiButtonBase';
 import MuiChip from './componentStylesOverrides/MuiChip';
 import MuiDrawer from './componentStylesOverrides/MuiDrawer';
 import MuiMenu from './componentStylesOverrides/MuiMenu';
 import MuiDialog from './componentStylesOverrides/MuiDialog';
+import MuiLinearProgress from './componentStylesOverrides/MuiLinearProgress';
+import MuiCircularProgress from './componentStylesOverrides/MuiCircularProgress';
+import MuiSwitch from './componentStylesOverrides/MuiSwitch';
+import MuiTab from './componentStylesOverrides/MuiTab';
+import MuiTabs from './componentStylesOverrides/MuiTabs';
+import MuiInputBase from './componentStylesOverrides/MuiInputBase';
+import MuiFilledInput from './componentStylesOverrides/MuiFilledInput';
+import MuiFormLabel from './componentStylesOverrides/MuiFormLabel';
+import MuiFormHelperText from './componentStylesOverrides/MuiFormHelperText';
+import MuiToggleButton from './componentStylesOverrides/MuiToggleButton';
+// shared overrides (identical between themes)
+import MuiBottomNavigationAction from './componentStylesOverrides/MuiBottomNavigationAction';
+import MuiBadge from './componentStylesOverrides/MuiBadge';
+import MuiBackdrop from './componentStylesOverrides/MuiBackdrop';
+import MuiButtonGroup from './componentStylesOverrides/MuiButtonGroup';
+import MuiCheckbox from './componentStylesOverrides/MuiCheckbox';
+import MuiButtonBase from './componentStylesOverrides/MuiButtonBase';
 import MuiFab from './componentStylesOverrides/MuiFab';
 import MuiListItem from './componentStylesOverrides/MuiListItem';
 import MuiListSubheader from './componentStylesOverrides/MuiListSubheader';
 import MuiMobileStepper from './componentStylesOverrides/MuiMobileStepper';
-import MuiLinearProgress from './componentStylesOverrides/MuiLinearProgress';
-import MuiCircularProgress from './componentStylesOverrides/MuiCircularProgress';
 import MuiSlider from './componentStylesOverrides/MuiSlider';
 import MuiSnackbarContent from './componentStylesOverrides/MuiSnackbarContent';
 import MuiStepConnector from './componentStylesOverrides/MuiStepConnector';
 import MuiStep from './componentStylesOverrides/MuiStep';
 import MuiStepIcon from './componentStylesOverrides/MuiStepIcon';
 import MuiStepLabel from './componentStylesOverrides/MuiStepLabel';
-import MuiSwitch from './componentStylesOverrides/MuiSwitch';
 import MuiTableCell from './componentStylesOverrides/MuiTableCell';
 import MuiTableHead from './componentStylesOverrides/MuiTableHead';
 import MuiTableRow from './componentStylesOverrides/MuiTableRow';
 import MuiTableSortLabel from './componentStylesOverrides/MuiTableSortLabel';
-import MuiTab from './componentStylesOverrides/MuiTab';
-import MuiTabs from './componentStylesOverrides/MuiTabs';
 import MuiTooltip from './componentStylesOverrides/MuiTooltip';
-import MuiInputBase from './componentStylesOverrides/MuiInputBase';
 import MuiInput from './componentStylesOverrides/MuiInput';
-import MuiFilledInput from './componentStylesOverrides/MuiFilledInput';
 import MuiOutlinedInput from './componentStylesOverrides/MuiOutlinedInput';
-import MuiFormLabel from './componentStylesOverrides/MuiFormLabel';
-import MuiFormHelperText from './componentStylesOverrides/MuiFormHelperText';
 import MuiToggleButtonGroup from './componentStylesOverrides/MuiToggleButtonGroup';
-import MuiToggleButton from './componentStylesOverrides/MuiToggleButton';
-
-// Light Theme Colors
-const LightThemeColors = {
-    primary: createSimplePalette(BLUIColors.blue),
-    secondary: createSimplePalette(BLUIColors.lightBlue),
-    error: createSimplePalette(BLUIColors.red),
-    success: createSimplePalette(BLUIColors.green),
-    info: createSimplePalette(BLUIColors.lightBlue),
-    divider: Color(BLUIColors.black[500]).alpha(0.12).string(),
-    warning: {
-        light: BLUIColors.yellow[100],
-        main: BLUIColors.yellow[500],
-        dark: BLUIColors.yellow[900],
-    },
-    background: {
-        default: BLUIColors.white[200],
-        paper: BLUIColors.white[50],
-    },
-    text: {
-        primary: BLUIColors.black[500],
-        secondary: BLUIColors.gray[500],
-        hint: BLUIColors.gray[500],
-    },
-    action: {
-        active: BLUIColors.gray[500],
-        disabled: Color(BLUIColors.black[500]).alpha(0.3).string(),
-    },
-};
-
-// Dark Theme Colors
-const DarkThemeColors = {
-    primary: createSimpleDarkPalette(BLUIColors.blue),
-    secondary: createSimpleDarkPalette(BLUIColors.lightBlue),
-    error: createSimpleDarkPalette(BLUIColors.red),
-    success: createSimpleDarkPalette(BLUIColors.green),
-    info: createSimpleDarkPalette(BLUIColors.lightBlue),
-    divider: Color(BLUIColors.black[200]).alpha(0.36).string(),
-    warning: {
-        light: BLUIColors.yellow[100],
-        main: BLUIColors.yellow[300],
-        dark: BLUIColors.yellow[900],
-    },
-    background: {
-        default: BLUIColors.darkBlack[900],
-        paper: BLUIColors.darkBlack[500],
-    },
-    text: {
-        primary: BLUIColors.black[50],
-        secondary: BLUIColors.black[200],
-        disabled: Color(BLUIColors.black[300]).alpha(0.36).string(),
-        hint: Color(BLUIColors.black[300]).alpha(0.36).string(),
-    },
-    action: {
-        hover: Color(BLUIColors.black[50]).alpha(0.1).string(),
-        active: BLUIColors.black[200],
-        disabled: Color(BLUIColors.black[300]).alpha(0.36).string(),
-        disabledBackground: Color(BLUIColors.black[200]).alpha(0.24).string(),
-    },
-};
+import { BlueLightThemeColors, BlueDarkThemeColors } from './blueColorScheme';
 
 const Spacing = 8;
 
@@ -116,13 +57,13 @@ export const blueThemes = createTheme({
         light: {
             palette: {
                 mode: 'light',
-                ...LightThemeColors,
+                ...BlueLightThemeColors,
             },
         },
         dark: {
             palette: {
                 mode: 'dark',
-                ...DarkThemeColors,
+                ...BlueDarkThemeColors,
             },
         },
     },

--- a/packages/themes/src/hmiBlueMergedTheme.ts
+++ b/packages/themes/src/hmiBlueMergedTheme.ts
@@ -1,0 +1,28 @@
+import { createTheme } from '@mui/material';
+import { typography } from './shared';
+import { hmiComponentOverrides } from './hmiTheme/hmiComponents';
+import { HmiLightThemeColors, HmiDarkThemeColors } from './hmiTheme/hmiBlueColorScheme';
+
+const Spacing = 8;
+
+export const blueThemes = createTheme({
+    cssVariables: { colorSchemeSelector: 'class' },
+    direction: 'ltr',
+    typography: typography,
+    spacing: Spacing,
+    colorSchemes: {
+        light: {
+            palette: {
+                mode: 'light',
+                ...HmiLightThemeColors,
+            },
+        },
+        dark: {
+            palette: {
+                mode: 'dark',
+                ...HmiDarkThemeColors,
+            },
+        },
+    },
+    components: hmiComponentOverrides,
+});

--- a/packages/themes/src/hmiTheme/GlobalSizeVariables.tsx
+++ b/packages/themes/src/hmiTheme/GlobalSizeVariables.tsx
@@ -1,0 +1,986 @@
+import React from 'react';
+import { GlobalStyles } from '@mui/material';
+
+const GlobalSizeVariables = (): React.ReactNode => (
+    <GlobalStyles
+        styles={{
+            '[data-size="s"]': {
+                // === Typography ===
+                '--blui-h1-font-size': '96px',
+                '--blui-h5-font-size': '30px',
+                '--blui-h6-font-size': '20px',
+                '--blui-subtitle1-font-size': '18px',
+                '--blui-subtitle2-font-size': '16px',
+                '--blui-body1-font-size': '16px',
+                '--blui-body2-font-size': '14px',
+                '--blui-caption-font-size': '12px',
+                '--blui-overline-font-size': '10px',
+                '--blui-button-font-size': '14px',
+                '--blui-overline-letter-spacing': '2px',
+                '--blui-overline-font-weight': '600',
+
+                // === Base Sizing ===
+                '--blui-bar-height': '56px',
+                '--blui-small-icon': '18px',
+                '--blui-normal-icon': '24px',
+                '--blui-dialog-radius': '4px',
+                '--blui-stroke': '1px',
+                '--blui-divider': '1px',
+                '--blui-screen-corner-radius': '4px',
+                '--blui-timestamp-width': '64px',
+                '--blui-toggle-knob': '20px',
+                '--blui-toggle-knob-icon': '18px',
+                '--blui-toggle-track': '14px',
+                '--blui-toggle-track-width': '34px',
+                '--blui-toggle-padding': '2px',
+                '--blui-toggle-container-padding': '12px',
+                '--blui-toggle-track-radius': '32px',
+                '--blui-toggle-track-opacity': '0.38',
+                '--blui-toggle-disabled-opacity': '0.8',
+                '--blui-slider-thin': '6px',
+                '--blui-tooltip-radius': '3px',
+                '--blui-tooltip-arrow': '12px',
+                '--blui-ring-chart-size': '64px',
+                '--blui-impact-icon': '96px',
+                '--blui-impact-avatar-icon': '80px',
+                '--blui-scrollbar-rail-width': '70px',
+                '--blui-appbar-padding': '16px',
+
+                // === Status Bar Sizing ===
+                '--blui-status-bar': '32px',
+                '--blui-status-text': '12px',
+                '--blui-status-icon': '24px',
+                '--blui-status-eaton-logo': '16px',
+
+                // === Empty State Sizing ===
+                '--blui-empty-state-icon': '96px',
+                '--blui-empty-state-spacing': '16px',
+                '--blui-empty-state-title': '0px',
+                '--blui-empty-state-body': '0px',
+
+                // === Navigation ===
+                '--blui-tab-text': '12px',
+                '--blui-tab-icon': '24px',
+                '--blui-indicator': '8px',
+                '--blui-drawer-width': '300px',
+                '--blui-drawer-item': '52px',
+                '--blui-drawer-eaton-logo': '28px',
+                '--blui-narrow-rail': '56px',
+                '--blui-wide-rail': '72px',
+                '--blui-rail-icon': '24px',
+                '--blui-indicator-border-radius': '32px',
+
+                // === Drawer ===
+                '--blui-drawer-header-title': '20px',
+                '--blui-drawer-header-subtitle': '16px',
+                '--blui-drawer-padding': '16px',
+                '--blui-drawer-title-weight': '600',
+                '--blui-drawer-subtitle-weight': '400',
+                '--blui-drawer-footer-gap': '8px',
+                '--blui-drawer-rail-header-gap': '16px',
+                '--blui-rail-footer-logo-width': '48px',
+                '--blui-rail-footer-logo-height': '13px',
+
+                // === Button ===
+                '--blui-button-height': '36px',
+                '--blui-button-text': '14px',
+                '--blui-button-icon': '18px',
+                '--blui-round-button-radius': '160px',
+                '--blui-button-radius': '4px',
+                '--blui-button-padding': '16px',
+                '--blui-selected-stroke': '2px',
+                '--blui-in-bar-button': '28px',
+                '--blui-disabled-button-border-width': '0px',
+                '--blui-segmented-button-height': '36px',
+                '--blui-segmented-button-padding': '16px',
+                '--blui-segmented-round-button-radius': '160px',
+
+                // === Avatar ===
+                '--blui-avatar-size': '40px',
+                '--blui-avatar-text': '16px',
+                '--blui-avatar-icon': '24px',
+                '--blui-avatar-grade-text': '16px',
+                '--blui-avatar-medium-size': '48px',
+                '--blui-avatar-medium-text': '16px',
+                '--blui-avatar-medium-icon': '32px',
+                '--blui-avatar-large-size': '64px',
+                '--blui-avatar-large-text': '26px',
+                '--blui-avatar-large-icon': '40px',
+                '--blui-avatar-extra-large-size': '72px',
+                '--blui-avatar-extra-large-text': '30px',
+                '--blui-avatar-extra-large-icon': '40px',
+                '--blui-avatar-extra-extra-large-size': '96px',
+                '--blui-avatar-extra-extra-large-text': '40px',
+                '--blui-avatar-extra-extra-large-icon': '40px',
+
+                // === Input ===
+                '--blui-input-padding': '8px',
+                '--blui-input-inner-height': '40px',
+                '--blui-input-dense-inner-height': '40px',
+                '--blui-input-assistive-height': '32px',
+                '--blui-input-text': '16px',
+                '--blui-input-stroke': '1px',
+                '--blui-input-active-stroke': '2px',
+                '--blui-input-radius': '4px',
+
+                // === Card ===
+                '--blui-card-radius': '4px',
+                '--blui-card-header-footer': '48px',
+                '--blui-card-header-foot-text': '14px',
+                '--blui-card-header-footer-icon': '24px',
+
+                // === Heroes ===
+                '--blui-hero-icon': '36px',
+                '--blui-hero-value': '20px',
+
+                // === List Item Tag ===
+                '--blui-list-item-min-height': '0px',
+                '--blui-list-item-tag-text': '10px',
+                '--blui-list-item-tag-weight': '800',
+                '--blui-list-item-tag-spacing': '2px',
+                '--blui-list-item-tag-height': '16px',
+                '--blui-list-item-tag-padding': '4px',
+                '--blui-list-item-tag-border-radius': '2px',
+                '--blui-list-item-tag-uppercase': 'true',
+
+                // === List Item ===
+                '--blui-status-stripe': '6px',
+                '--blui-resistive-scrollbar': '54px',
+                '--blui-system-scrollbar': '6px',
+                '--blui-info-list-item-padding': '16px',
+
+                // === Chip ===
+                '--blui-chip-height': '32px',
+                '--blui-chip-radius': '160px',
+                '--blui-chip-rectangular-radius': '8px',
+                '--blui-chip-icon': '18px',
+                '--blui-chip-avatar': '24px',
+                '--blui-chip-avatar-text': '10px',
+                '--blui-module-width': '136px',
+                '--blui-module-tile-width': '64px',
+                '--blui-chip-avatar-radius': '200px',
+
+                // === Progress and Steppers ===
+                '--blui-progress-bar': '4px',
+                '--blui-stepper-dot': '8px',
+                '--blui-stepper-padding': '4px',
+                '--blui-snackbar-progress-bar': '56px',
+                '--blui-linear-stepper-avatar': '24px',
+                '--blui-linear-stepper-icon': '16px',
+            },
+            '[data-size="m"]': {
+                // === Typography ===
+                '--blui-h1-font-size': '104px',
+                '--blui-h5-font-size': '36px',
+                '--blui-h6-font-size': '24px',
+                '--blui-subtitle1-font-size': '22px',
+                '--blui-subtitle2-font-size': '20px',
+                '--blui-body1-font-size': '20px',
+                '--blui-body2-font-size': '20px',
+                '--blui-caption-font-size': '18px',
+                '--blui-overline-font-size': '16px',
+                '--blui-button-font-size': '24px',
+                '--blui-overline-letter-spacing': '3px',
+                '--blui-overline-font-weight': '600',
+
+                // === Base Sizing ===
+                '--blui-bar-height': '96px',
+                '--blui-small-icon': '20px',
+                '--blui-normal-icon': '32px',
+                '--blui-dialog-radius': '40px',
+                '--blui-stroke': '2px',
+                '--blui-divider': '2px',
+                '--blui-screen-corner-radius': '12px',
+                '--blui-timestamp-width': '72px',
+                '--blui-toggle-knob': '28px',
+                '--blui-toggle-knob-icon': '24px',
+                '--blui-toggle-track': '20px',
+                '--blui-toggle-track-width': '48px',
+                '--blui-toggle-padding': '2px',
+                '--blui-toggle-container-padding': '12px',
+                '--blui-toggle-track-radius': '32px',
+                '--blui-toggle-track-opacity': '0.38',
+                '--blui-toggle-disabled-opacity': '0.8',
+                '--blui-slider-thin': '12px',
+                '--blui-tooltip-radius': '6px',
+                '--blui-tooltip-arrow': '20px',
+                '--blui-ring-chart-size': '72px',
+                '--blui-impact-icon': '120px',
+                '--blui-impact-avatar-icon': '88px',
+
+                // === Status Bar Sizing ===
+                '--blui-status-bar': '56px',
+                '--blui-status-text': '24px',
+                '--blui-status-icon': '32px',
+                '--blui-status-eaton-logo': '24px',
+
+                // === Empty State Sizing ===
+                '--blui-empty-state-icon': '120px',
+                '--blui-empty-state-spacing': '24px',
+                '--blui-empty-state-title': '0px',
+                '--blui-empty-state-body': '0px',
+
+                // === Navigation ===
+                '--blui-tab-text': '20px',
+                '--blui-tab-icon': '32px',
+                '--blui-indicator': '16px',
+                '--blui-drawer-width': '360px',
+                '--blui-drawer-item': '68px',
+                '--blui-drawer-eaton-logo': '36px',
+                '--blui-narrow-rail': '64px',
+                '--blui-wide-rail': '88px',
+                '--blui-rail-icon': '32px',
+                '--blui-indicator-border-radius': '32px',
+
+                // === Drawer ===
+                '--blui-drawer-header-title': '24px',
+                '--blui-drawer-header-subtitle': '20px',
+                '--blui-drawer-padding': '16px',
+                '--blui-drawer-title-weight': '600',
+                '--blui-drawer-subtitle-weight': '400',
+                '--blui-drawer-footer-gap': '8px',
+                '--blui-drawer-rail-header-gap': '32px',
+                '--blui-rail-footer-logo-width': '48px',
+                '--blui-rail-footer-logo-height': '13px',
+
+                // === Button ===
+                '--blui-button-height': '56px',
+                '--blui-button-text': '24px',
+                '--blui-button-icon': '32px',
+                '--blui-round-button-radius': '160px',
+                '--blui-button-radius': '8px',
+                '--blui-button-padding': '32px',
+                '--blui-selected-stroke': '4px',
+                '--blui-in-bar-button': '48px',
+                '--blui-disabled-button-border-width': '0px',
+                '--blui-segmented-button-height': '56px',
+                '--blui-segmented-button-padding': '24px',
+                '--blui-segmented-round-button-radius': '160px',
+
+                // === Avatar ===
+                '--blui-avatar-size': '64px',
+                '--blui-avatar-text': '24px',
+                '--blui-avatar-icon': '32px',
+                '--blui-avatar-grade-text': '24px',
+                '--blui-avatar-medium-size': '64px',
+                '--blui-avatar-medium-text': '24px',
+                '--blui-avatar-medium-icon': '32px',
+                '--blui-avatar-large-size': '80px',
+                '--blui-avatar-large-text': '40px',
+                '--blui-avatar-large-icon': '48px',
+                '--blui-avatar-extra-large-size': '96px',
+                '--blui-avatar-extra-large-text': '40px',
+                '--blui-avatar-extra-large-icon': '40px',
+                '--blui-avatar-extra-extra-large-size': '112px',
+                '--blui-avatar-extra-extra-large-text': '48px',
+                '--blui-avatar-extra-extra-large-icon': '40px',
+
+                // === Input ===
+                '--blui-input-padding': '8px',
+                '--blui-input-inner-height': '56px',
+                '--blui-input-dense-inner-height': '64px',
+                '--blui-input-assistive-height': '40px',
+                '--blui-input-text': '24px',
+                '--blui-input-stroke': '2px',
+                '--blui-input-active-stroke': '4px',
+                '--blui-input-radius': '6px',
+
+                // === Card ===
+                '--blui-card-radius': '8px',
+                '--blui-card-header-footer': '64px',
+                '--blui-card-header-foot-text': '20px',
+                '--blui-card-header-footer-icon': '32px',
+
+                // === Heroes ===
+                '--blui-hero-icon': '44px',
+                '--blui-hero-value': '28px',
+
+                // === List Item Tag ===
+                '--blui-list-item-min-height': '0px',
+                '--blui-list-item-tag-text': '14px',
+                '--blui-list-item-tag-weight': '800',
+                '--blui-list-item-tag-spacing': '3px',
+                '--blui-list-item-tag-height': '20px',
+                '--blui-list-item-tag-padding': '6px',
+                '--blui-list-item-tag-border-radius': '2px',
+                '--blui-list-item-tag-uppercase': 'true',
+
+                // === List Item ===
+                '--blui-status-stripe': '12px',
+                '--blui-resistive-scrollbar': '54px',
+                '--blui-system-scrollbar': '12px',
+                '--blui-scrollbar-rail-width': '70px',
+                '--blui-info-list-item-padding': '16px',
+
+                // === Chip ===
+                '--blui-chip-height': '40px',
+                '--blui-chip-radius': '160px',
+                '--blui-chip-rectangular-radius': '16px',
+                '--blui-chip-icon': '28px',
+                '--blui-chip-avatar': '32px',
+                '--blui-chip-avatar-text': '14px',
+                '--blui-module-width': '152px',
+                '--blui-module-tile-width': '80px',
+                '--blui-chip-avatar-radius': '200px',
+
+                // === Progress and Steppers ===
+                '--blui-progress-bar': '8px',
+                '--blui-stepper-dot': '12px',
+                '--blui-stepper-padding': '6px',
+                '--blui-snackbar-progress-bar': '96px',
+                '--blui-linear-stepper-avatar': '32px',
+                '--blui-linear-stepper-icon': '24px',
+            },
+            '[data-size="l"]': {
+                // === Typography ===
+                '--blui-h1-font-size': '104px',
+                '--blui-h5-font-size': '36px',
+                '--blui-h6-font-size': '24px',
+                '--blui-subtitle1-font-size': '22px',
+                '--blui-subtitle2-font-size': '20px',
+                '--blui-body1-font-size': '20px',
+                '--blui-body2-font-size': '20px',
+                '--blui-caption-font-size': '18px',
+                '--blui-overline-font-size': '16px',
+                '--blui-button-font-size': '24px',
+                '--blui-overline-letter-spacing': '3px',
+                '--blui-overline-font-weight': '600',
+
+                // === Base Sizing ===
+                '--blui-bar-height': '96px',
+                '--blui-small-icon': '20px',
+                '--blui-normal-icon': '32px',
+                '--blui-dialog-radius': '40px',
+                '--blui-stroke': '2px',
+                '--blui-divider': '2px',
+                '--blui-screen-corner-radius': '12px',
+                '--blui-timestamp-width': '72px',
+                '--blui-toggle-knob': '28px',
+                '--blui-toggle-knob-icon': '24px',
+                '--blui-toggle-track': '20px',
+                '--blui-toggle-track-width': '48px',
+                '--blui-toggle-padding': '2px',
+                '--blui-toggle-container-padding': '12px',
+                '--blui-toggle-track-radius': '32px',
+                '--blui-toggle-track-opacity': '0.38',
+                '--blui-toggle-disabled-opacity': '0.8',
+                '--blui-slider-thin': '16px',
+                '--blui-tooltip-radius': '6px',
+                '--blui-tooltip-arrow': '20px',
+                '--blui-ring-chart-size': '72px',
+                '--blui-impact-icon': '120px',
+                '--blui-impact-avatar-icon': '88px',
+
+                // === Status Bar Sizing ===
+                '--blui-status-bar': '64px',
+                '--blui-status-text': '24px',
+                '--blui-status-icon': '32px',
+                '--blui-status-eaton-logo': '28px',
+
+                // === Empty State Sizing ===
+                '--blui-empty-state-icon': '120px',
+                '--blui-empty-state-spacing': '24px',
+                '--blui-empty-state-title': '0px',
+                '--blui-empty-state-body': '0px',
+
+                // === Navigation ===
+                '--blui-tab-text': '20px',
+                '--blui-tab-icon': '32px',
+                '--blui-indicator': '16px',
+                '--blui-drawer-width': '360px',
+                '--blui-drawer-item': '68px',
+                '--blui-drawer-eaton-logo': '36px',
+                '--blui-narrow-rail': '64px',
+                '--blui-wide-rail': '88px',
+                '--blui-rail-icon': '32px',
+                '--blui-indicator-border-radius': '32px',
+
+                // === Drawer ===
+                '--blui-drawer-header-title': '24px',
+                '--blui-drawer-header-subtitle': '20px',
+                '--blui-drawer-padding': '16px',
+                '--blui-drawer-title-weight': '600',
+                '--blui-drawer-subtitle-weight': '400',
+                '--blui-drawer-footer-gap': '8px',
+                '--blui-drawer-rail-header-gap': '32px',
+                '--blui-rail-footer-logo-width': '48px',
+                '--blui-rail-footer-logo-height': '13px',
+
+                // === Button ===
+                '--blui-button-height': '80px',
+                '--blui-button-text': '24px',
+                '--blui-button-icon': '32px',
+                '--blui-round-button-radius': '160px',
+                '--blui-button-radius': '12px',
+                '--blui-button-padding': '24px',
+                '--blui-selected-stroke': '4px',
+                '--blui-in-bar-button': '48px',
+                '--blui-disabled-button-border-width': '0px',
+                '--blui-segmented-button-height': '80px',
+                '--blui-segmented-button-padding': '32px',
+                '--blui-segmented-round-button-radius': '160px',
+
+                // === Avatar ===
+                '--blui-avatar-size': '64px',
+                '--blui-avatar-text': '24px',
+                '--blui-avatar-icon': '32px',
+                '--blui-avatar-grade-text': '24px',
+                '--blui-avatar-medium-size': '64px',
+                '--blui-avatar-medium-text': '24px',
+                '--blui-avatar-medium-icon': '32px',
+                '--blui-avatar-large-size': '80px',
+                '--blui-avatar-large-text': '32px',
+                '--blui-avatar-large-icon': '48px',
+                '--blui-avatar-extra-large-size': '96px',
+                '--blui-avatar-extra-large-text': '40px',
+                '--blui-avatar-extra-large-icon': '40px',
+                '--blui-avatar-extra-extra-large-size': '112px',
+                '--blui-avatar-extra-extra-large-text': '48px',
+                '--blui-avatar-extra-extra-large-icon': '40px',
+
+                // === Input ===
+                '--blui-input-padding': '8px',
+                '--blui-input-inner-height': '64px',
+                '--blui-input-dense-inner-height': '72px',
+                '--blui-input-assistive-height': '40px',
+                '--blui-input-text': '24px',
+                '--blui-input-stroke': '2px',
+                '--blui-input-active-stroke': '4px',
+                '--blui-input-radius': '6px',
+
+                // === Card ===
+                '--blui-card-radius': '8px',
+                '--blui-card-header-footer': '64px',
+                '--blui-card-header-foot-text': '20px',
+                '--blui-card-header-footer-icon': '32px',
+
+                // === Heroes ===
+                '--blui-hero-icon': '44px',
+                '--blui-hero-value': '28px',
+
+                // === List Item Tag ===
+                '--blui-list-item-min-height': '0px',
+                '--blui-list-item-tag-text': '14px',
+                '--blui-list-item-tag-weight': '800',
+                '--blui-list-item-tag-spacing': '3px',
+                '--blui-list-item-tag-height': '20px',
+                '--blui-list-item-tag-padding': '6px',
+                '--blui-list-item-tag-border-radius': '2px',
+                '--blui-list-item-tag-uppercase': 'true',
+
+                // === List Item ===
+                '--blui-status-stripe': '12px',
+                '--blui-resistive-scrollbar': '54px',
+                '--blui-system-scrollbar': '12px',
+                '--blui-scrollbar-rail-width': '70px',
+                '--blui-info-list-item-padding': '16px',
+
+                // === Chip ===
+                '--blui-chip-height': '40px',
+                '--blui-chip-radius': '160px',
+                '--blui-chip-rectangular-radius': '16px',
+                '--blui-chip-icon': '28px',
+                '--blui-chip-avatar': '32px',
+                '--blui-chip-avatar-text': '14px',
+                '--blui-module-width': '160px',
+                '--blui-module-tile-width': '80px',
+                '--blui-chip-avatar-radius': '200px',
+
+                // === Progress and Steppers ===
+                '--blui-progress-bar': '10px',
+                '--blui-stepper-dot': '16px',
+                '--blui-stepper-padding': '8px',
+                '--blui-snackbar-progress-bar': '96px',
+                '--blui-linear-stepper-avatar': '32px',
+                '--blui-linear-stepper-icon': '24px',
+            },
+            // Direct CSS targeting for @brightlayer-ui/react-components EmptyState
+            '[data-size="s"] .BluiEmptyState-root': {
+                padding: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="s"] .BluiEmptyState-icon': {
+                fontSize: 'var(--blui-empty-state-icon)',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="s"] .BluiEmptyState-icon svg': {
+                fontSize: 'var(--blui-empty-state-icon) !important',
+            },
+            '[data-size="s"] .BluiEmptyState-title': {
+                fontSize: 'var(--blui-h6-font-size) !important',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="s"] .BluiEmptyState-description': {
+                fontSize: 'var(--blui-subtitle2-font-size) !important',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            // Medium size targeting
+            '[data-size="m"] .BluiEmptyState-root': {
+                padding: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="m"] .BluiEmptyState-icon': {
+                fontSize: 'var(--blui-empty-state-icon)',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="m"] .BluiEmptyState-icon svg': {
+                fontSize: 'var(--blui-empty-state-icon) !important',
+            },
+            '[data-size="m"] .BluiEmptyState-title': {
+                fontSize: 'var(--blui-h6-font-size) !important',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="m"] .BluiEmptyState-description': {
+                fontSize: 'var(--blui-subtitle2-font-size) !important',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            // Large size targeting
+            '[data-size="l"] .BluiEmptyState-root': {
+                padding: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="l"] .BluiEmptyState-icon': {
+                fontSize: 'var(--blui-empty-state-icon)',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="l"] .BluiEmptyState-icon svg': {
+                fontSize: 'var(--blui-empty-state-icon) !important',
+            },
+            '[data-size="l"] .BluiEmptyState-title': {
+                fontSize: 'var(--blui-h6-font-size) !important',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            '[data-size="l"] .BluiEmptyState-description': {
+                fontSize: 'var(--blui-subtitle2-font-size) !important',
+                marginBottom: 'var(--blui-empty-state-spacing)',
+            },
+            // Direct CSS targeting for @brightlayer-ui/react-components AppBar
+            '[data-size="s"] .BluiAppBar-root': {
+                padding: '0 var(--blui-appbar-padding)',
+            },
+            '[data-size="s"] .BluiAppBar-collapsed': {
+                height: 'var(--blui-bar-height) !important',
+            },
+            '[data-size="s"] .BluiAppBar-root.Mui-expanded': {
+                padding: 'var(--blui-appbar-padding) !important',
+            },
+            '[data-size="m"] .BluiAppBar-root': {
+                padding: '0 var(--blui-appbar-padding)',
+            },
+            '[data-size="m"] .BluiAppBar-collapsed': {
+                height: 'var(--blui-bar-height) !important',
+            },
+            '[data-size="m"] .BluiAppBar-root.Mui-expanded': {
+                padding: '16px',
+            },
+            '[data-size="l"] .BluiAppBar-root': {
+                padding: '0 var(--blui-appbar-padding)',
+            },
+            '[data-size="l"] .BluiAppBar-collapsed': {
+                height: 'var(--blui-bar-height) !important',
+            },
+            '[data-size="l"] .BluiAppBar-root.Mui-expanded': {
+                padding: '16px',
+            },
+            // === Drawer Component Overrides ===
+            // Drawer - Size S
+            '[data-size="s"] .BluiDrawer-root': {
+                width: 'var(--blui-drawer-width) !important',
+            },
+            '[data-size="s"] .BluiDrawer-content': {
+                width: 'var(--blui-drawer-width) !important',
+            },
+            '[data-size="s"] .BluiDrawerHeader-root': {
+                height: 'var(--blui-bar-height) !important',
+                // padding: '0 16px !important',
+                // gap: '16px !important',
+            },
+            '[data-size="s"] .BluiDrawerHeader-navigation svg': {
+                width: 'var(--blui-normal-icon) !important',
+                height: 'var(--blui-normal-icon) !important',
+            },
+            '[data-size="s"] .BluiDrawerHeader-title': {
+                fontSize: 'var(--blui-drawer-header-title) !important',
+                fontWeight: 'var(--blui-drawer-title-weight) !important',
+            },
+            '[data-size="s"] .BluiDrawerHeader-subtitle': {
+                fontSize: 'var(--blui-drawer-header-subtitle) !important',
+                fontWeight: 'var(--blui-drawer-subtitle-weight) !important',
+            },
+            '[data-size="s"] .BluiDrawerNavItem-root': {
+                display: 'flex !important',
+                width: 'var(--blui-drawer-width) !important',
+                height: 'var(--blui-drawer-item) !important',
+                alignItems: 'center !important',
+            },
+            '[data-size="s"] .BluiDrawerNavItem-title': {
+                flex: '1 0 0 !important',
+                fontSize: 'var(--blui-drawer-header-subtitle) !important',
+                fontWeight: 'var(--blui-drawer-subtitle-weight) !important',
+                lineHeight: 'normal !important',
+            },
+            '[data-size="s"] .BluiDrawerNavItem-titleActive': {
+                fontWeight: 'var(--blui-drawer-title-weight) !important',
+            },
+            '[data-size="s"] .BluiDrawerFooter-root': {
+                width: 'var(--blui-drawer-width) !important',
+                minHeight: 'var(--blui-bar-height) !important',
+                padding: 'var(--blui-drawer-padding) !important',
+                gap: 'var(--blui-drawer-footer-gap) !important',
+            },
+            '[data-size="s"] .BluiDrawerFooter-root > div > div > div:last-child': {
+                display: 'flex !important',
+                flexDirection: 'column !important',
+                justifyContent: 'center !important',
+                alignItems: 'flex-end !important',
+                flex: '1 0 0 !important',
+            },
+            '[data-size="s"] .BluiDrawerFooter-root .MuiTypography-caption': {
+                fontSize: 'var(--blui-caption-font-size) !important',
+                lineHeight: 'normal !important',
+            },
+            '[data-size="s"] .BluiDrawerRailItem-root': {
+                display: 'flex !important',
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-wide-rail) !important',
+                padding: 'var(--blui-drawer-padding) 8px !important',
+                flexDirection: 'column !important',
+                justifyContent: 'center !important',
+                alignItems: 'center !important',
+            },
+            '[data-size="s"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerHeader-root': {
+                display: 'flex !important',
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-bar-height) !important',
+                padding: '0 var(--blui-drawer-padding) !important',
+                justifyContent: 'center !important',
+                alignItems: 'center !important',
+                gap: 'var(--blui-drawer-rail-header-gap) !important',
+                flexShrink: '0 !important',
+            },
+            '[data-size="s"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerHeader-content': {
+                display: 'none !important',
+            },
+            '[data-size="s"] .BluiDrawer-root:has(.BluiDrawerRailItem-root)': {
+                width: 'var(--blui-wide-rail) !important',
+            },
+            '[data-size="s"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerFooter-root': {
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-wide-rail) !important',
+            },
+            '[data-size="s"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerFooter-root img': {
+                width: 'var(--blui-rail-footer-logo-width) !important',
+                height: 'var(--blui-rail-footer-logo-height) !important',
+            },
+            '[data-size="s"] .BluiDrawer-rail .BluiDrawer-content': {
+                width: 'var(--blui-wide-rail) !important',
+            },
+
+            // Drawer - Size M
+            '[data-size="m"] .BluiDrawer-root': {
+                width: 'var(--blui-drawer-width) !important',
+            },
+            '[data-size="m"] .BluiDrawer-content': {
+                width: 'var(--blui-drawer-width) !important',
+            },
+            '[data-size="m"] .BluiDrawerHeader-root': {
+                height: 'var(--blui-bar-height) !important',
+                // padding: '0 16px !important',
+                // gap: '32px !important',
+            },
+            '[data-size="m"] .BluiDrawerHeader-navigation svg': {
+                width: 'var(--blui-normal-icon) !important',
+                height: 'var(--blui-normal-icon) !important',
+            },
+            '[data-size="m"] .BluiDrawerHeader-title': {
+                fontSize: 'var(--blui-drawer-header-title) !important',
+                fontWeight: 'var(--blui-drawer-title-weight) !important',
+                lineHeight: 'initial !important',
+            },
+            '[data-size="m"] .BluiDrawerHeader-subtitle': {
+                fontSize: 'var(--blui-drawer-header-subtitle) !important',
+                fontWeight: 'var(--blui-drawer-subtitle-weight) !important',
+            },
+            '[data-size="m"] .BluiDrawerNavItem-root': {
+                display: 'flex !important',
+                width: 'var(--blui-drawer-width) !important',
+                height: 'var(--blui-drawer-item) !important',
+                alignItems: 'center !important',
+            },
+            '[data-size="m"] .BluiDrawerNavItem-title': {
+                flex: '1 0 0 !important',
+                fontSize: 'var(--blui-drawer-header-subtitle) !important',
+                fontWeight: 'var(--blui-drawer-subtitle-weight) !important',
+                lineHeight: 'normal !important',
+            },
+            '[data-size="m"] .BluiDrawerNavItem-titleActive': {
+                fontWeight: 'var(--blui-drawer-title-weight) !important',
+            },
+            '[data-size="m"] .BluiDrawerFooter-root': {
+                width: 'var(--blui-drawer-width) !important',
+                minHeight: 'var(--blui-bar-height) !important',
+                padding: 'var(--blui-drawer-padding) !important',
+                gap: 'var(--blui-drawer-footer-gap) !important',
+            },
+            '[data-size="m"] .BluiDrawerFooter-root > div > div > div:last-child': {
+                display: 'flex !important',
+                flexDirection: 'column !important',
+                justifyContent: 'center !important',
+                alignItems: 'flex-end !important',
+                flex: '1 0 0 !important',
+            },
+            '[data-size="m"] .BluiDrawerFooter-root .MuiTypography-caption': {
+                fontSize: 'var(--blui-caption-font-size) !important',
+                lineHeight: 'normal !important',
+            },
+            '[data-size="m"] .BluiDrawerRailItem-root': {
+                display: 'flex !important',
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-wide-rail) !important',
+                padding: 'var(--blui-drawer-padding) 8px !important',
+                flexDirection: 'column !important',
+                justifyContent: 'center !important',
+                alignItems: 'center !important',
+            },
+            '[data-size="m"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerHeader-root': {
+                display: 'flex !important',
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-bar-height) !important',
+                padding: '0 var(--blui-drawer-padding) !important',
+                justifyContent: 'center !important',
+                alignItems: 'center !important',
+                gap: 'var(--blui-drawer-rail-header-gap) !important',
+                flexShrink: '0 !important',
+            },
+            '[data-size="m"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerHeader-content': {
+                display: 'none !important',
+            },
+            '[data-size="m"] .BluiDrawer-root:has(.BluiDrawerRailItem-root)': {
+                width: 'var(--blui-wide-rail) !important',
+            },
+            '[data-size="m"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerFooter-root': {
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-wide-rail) !important',
+            },
+            '[data-size="m"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerFooter-root img': {
+                width: 'var(--blui-rail-footer-logo-width) !important',
+                height: 'var(--blui-rail-footer-logo-height) !important',
+            },
+            '[data-size="m"] .BluiDrawer-rail .BluiDrawer-content': {
+                width: 'var(--blui-wide-rail) !important',
+            },
+
+            // Drawer - Size L
+            '[data-size="l"] .BluiDrawer-root': {
+                width: 'var(--blui-drawer-width) !important',
+            },
+            '[data-size="l"] .BluiDrawer-content': {
+                width: 'var(--blui-drawer-width) !important',
+            },
+            '[data-size="l"] .BluiDrawerHeader-root': {
+                height: 'var(--blui-bar-height) !important',
+                // padding: '0 16px !important',
+                // gap: '32px !important',
+            },
+            '[data-size="l"] .BluiDrawerHeader-navigation svg': {
+                width: 'var(--blui-normal-icon) !important',
+                height: 'var(--blui-normal-icon) !important',
+            },
+            '[data-size="l"] .BluiDrawerHeader-title': {
+                fontSize: 'var(--blui-drawer-header-title) !important',
+                fontWeight: 'var(--blui-drawer-title-weight) !important',
+                lineHeight: 'initial !important',
+            },
+            '[data-size="l"] .BluiDrawerHeader-subtitle': {
+                fontSize: 'var(--blui-drawer-header-subtitle) !important',
+                fontWeight: 'var(--blui-drawer-subtitle-weight) !important',
+            },
+            '[data-size="l"] .BluiDrawerNavItem-root': {
+                display: 'flex !important',
+                width: 'var(--blui-drawer-width) !important',
+                height: 'var(--blui-drawer-item) !important',
+                alignItems: 'center !important',
+            },
+            '[data-size="l"] .BluiDrawerNavItem-title': {
+                flex: '1 0 0 !important',
+                fontSize: 'var(--blui-drawer-header-subtitle) !important',
+                fontWeight: 'var(--blui-drawer-subtitle-weight) !important',
+                lineHeight: 'normal !important',
+            },
+            '[data-size="l"] .BluiDrawerNavItem-titleActive': {
+                fontWeight: 'var(--blui-drawer-title-weight) !important',
+            },
+            '[data-size="l"] .BluiDrawerFooter-root': {
+                width: 'var(--blui-drawer-width) !important',
+                minHeight: 'var(--blui-bar-height) !important',
+                padding: 'var(--blui-drawer-padding) !important',
+                gap: 'var(--blui-drawer-footer-gap) !important',
+            },
+            '[data-size="l"] .BluiDrawerFooter-root > div > div > div:last-child': {
+                display: 'flex !important',
+                flexDirection: 'column !important',
+                justifyContent: 'center !important',
+                alignItems: 'flex-end !important',
+                flex: '1 0 0 !important',
+            },
+            '[data-size="l"] .BluiDrawerFooter-root .MuiTypography-caption': {
+                fontSize: 'var(--blui-caption-font-size) !important',
+                lineHeight: 'normal !important',
+            },
+            '[data-size="l"] .BluiDrawerRailItem-root': {
+                display: 'flex !important',
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-wide-rail) !important',
+                padding: 'var(--blui-drawer-padding) 8px !important',
+                flexDirection: 'column !important',
+                justifyContent: 'center !important',
+                alignItems: 'center !important',
+            },
+            '[data-size="l"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerHeader-root': {
+                display: 'flex !important',
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-bar-height) !important',
+                padding: '0 var(--blui-drawer-padding) !important',
+                justifyContent: 'center !important',
+                alignItems: 'center !important',
+                gap: 'var(--blui-drawer-rail-header-gap) !important',
+                flexShrink: '0 !important',
+            },
+            '[data-size="l"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerHeader-content': {
+                display: 'none !important',
+            },
+            '[data-size="l"] .BluiDrawer-root:has(.BluiDrawerRailItem-root)': {
+                width: 'var(--blui-wide-rail) !important',
+            },
+            '[data-size="l"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerFooter-root': {
+                width: 'var(--blui-wide-rail) !important',
+                height: 'var(--blui-wide-rail) !important',
+            },
+            '[data-size="l"] .BluiDrawer-root:has(.BluiDrawerRailItem-root) .BluiDrawerFooter-root img': {
+                width: 'var(--blui-rail-footer-logo-width) !important',
+                height: 'var(--blui-rail-footer-logo-height) !important',
+            },
+            '[data-size="l"] .BluiDrawer-rail .BluiDrawer-content': {
+                width: 'var(--blui-wide-rail) !important',
+            },
+
+            // Direct CSS targeting for @brightlayer-ui/react-components ListItemTag
+            '[data-size="s"] .BluiListItemTag-root': {
+                fontSize: 'var(--blui-list-item-tag-text) !important',
+                fontWeight: 'var(--blui-list-item-tag-weight) !important',
+                letterSpacing: 'var(--blui-list-item-tag-spacing) !important',
+                height: 'var(--blui-list-item-tag-height) !important',
+                padding: '0 var(--blui-list-item-tag-padding) !important',
+                borderRadius: 'var(--blui-list-item-tag-border-radius) !important',
+                textTransform: 'uppercase',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 'var(--blui-list-item-tag-height)',
+                lineHeight: 'var(--blui-list-item-tag-height) !important',
+            },
+            '[data-size="m"] .BluiListItemTag-root': {
+                fontSize: 'var(--blui-list-item-tag-text) !important',
+                fontWeight: 'var(--blui-list-item-tag-weight) !important',
+                letterSpacing: 'var(--blui-list-item-tag-spacing) !important',
+                height: 'var(--blui-list-item-tag-height) !important',
+                padding: '0 var(--blui-list-item-tag-padding) !important',
+                borderRadius: 'var(--blui-list-item-tag-border-radius) !important',
+                textTransform: 'uppercase',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 'var(--blui-list-item-tag-height)',
+                lineHeight: 'var(--blui-list-item-tag-height) !important',
+            },
+            '[data-size="l"] .BluiListItemTag-root': {
+                fontSize: 'var(--blui-list-item-tag-text) !important',
+                fontWeight: 'var(--blui-list-item-tag-weight) !important',
+                letterSpacing: 'var(--blui-list-item-tag-spacing) !important',
+                height: 'var(--blui-list-item-tag-height) !important',
+                padding: '0 var(--blui-list-item-tag-padding) !important',
+                borderRadius: 'var(--blui-list-item-tag-border-radius) !important',
+                textTransform: 'uppercase',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minWidth: 'var(--blui-list-item-tag-height)',
+                lineHeight: 'var(--blui-list-item-tag-height) !important',
+            },
+            // Direct CSS targeting for @brightlayer-ui/react-components Hero
+            '[data-size="s"] .BluiHero-icon': {
+                fontSize: 'var(--blui-hero-icon)',
+            },
+            '[data-size="s"] .BluiHero-icon svg': {
+                fontSize: 'var(--blui-hero-icon) !important',
+            },
+            '[data-size="s"] .BluiChannelValue-root': {
+                marginTop: '4px',
+            },
+            '[data-size="s"] .BluiChannelValue-icon': {
+                fontSize: 'var(--blui-normal-icon)',
+            },
+            '[data-size="s"] .BluiChannelValue-icon svg': {
+                fontSize: 'var(--blui-normal-icon) !important',
+            },
+            '[data-size="s"] .BluiChannelValue-value': {
+                fontSize: 'var(--blui-hero-value) !important',
+            },
+            '[data-size="s"] .BluiChannelValue-units': {
+                fontSize: 'var(--blui-hero-value) !important',
+            },
+            '[data-size="s"] .BluiHero-label': {
+                fontSize: 'var(--blui-subtitle2-font-size) !important',
+            },
+            // Medium size targeting
+            '[data-size="m"] .BluiHero-icon': {
+                fontSize: 'var(--blui-hero-icon)',
+            },
+            '[data-size="m"] .BluiHero-icon svg': {
+                fontSize: 'var(--blui-hero-icon) !important',
+            },
+            '[data-size="m"] .BluiChannelValue-root': {
+                marginTop: '4px',
+            },
+            '[data-size="m"] .BluiChannelValue-icon': {
+                fontSize: 'var(--blui-normal-icon)',
+            },
+            '[data-size="m"] .BluiChannelValue-icon svg': {
+                fontSize: 'var(--blui-normal-icon) !important',
+            },
+            '[data-size="m"] .BluiChannelValue-value': {
+                fontSize: 'var(--blui-hero-value) !important',
+            },
+            '[data-size="m"] .BluiChannelValue-units': {
+                fontSize: 'var(--blui-hero-value) !important',
+            },
+            '[data-size="m"] .BluiHero-label': {
+                fontSize: 'var(--blui-subtitle2-font-size) !important',
+            },
+            // Large size targeting
+            '[data-size="l"] .BluiHero-icon': {
+                fontSize: 'var(--blui-hero-icon)',
+            },
+            '[data-size="l"] .BluiHero-icon svg': {
+                fontSize: 'var(--blui-hero-icon) !important',
+            },
+            '[data-size="l"] .BluiChannelValue-root': {
+                marginTop: '4px',
+            },
+            '[data-size="l"] .BluiChannelValue-icon': {
+                fontSize: 'var(--blui-normal-icon)',
+            },
+            '[data-size="l"] .BluiChannelValue-icon svg': {
+                fontSize: 'var(--blui-normal-icon) !important',
+            },
+            '[data-size="l"] .BluiChannelValue-value': {
+                fontSize: 'var(--blui-hero-value) !important',
+            },
+            '[data-size="l"] .BluiChannelValue-units': {
+                fontSize: 'var(--blui-hero-value) !important',
+            },
+            '[data-size="l"] .BluiHero-label': {
+                fontSize: 'var(--blui-subtitle2-font-size) !important',
+            },
+        }}
+    />
+);
+
+export default GlobalSizeVariables;

--- a/packages/themes/src/hmiTheme/hmiBlueColorScheme.ts
+++ b/packages/themes/src/hmiTheme/hmiBlueColorScheme.ts
@@ -1,0 +1,71 @@
+import { createSimpleLightPalette as createSimplePalette } from '../shared';
+import * as BLUIColors from '@brightlayer-ui/colors';
+import Color from 'color';
+import { BlueLightThemeColors, BlueDarkThemeColors } from '../blueColorScheme';
+
+export const HmiLightThemeColors = {
+    ...BlueLightThemeColors,
+    warningAlternate: createSimplePalette(BLUIColors.orange),
+    scrollbar: {
+        button: BLUIColors.white[50],
+    },
+    statusBar: {
+        default: BLUIColors.white[200],
+        alarm: BLUIColors.red[900],
+        warning: BLUIColors.gold[700],
+        success: BLUIColors.green[700],
+        primary: BLUIColors.blue[700],
+    },
+    gauge: {
+        progress: BLUIColors.green[700],
+        track: Color('#178E0B').alpha(0.1).string(), //@TODO: Verify track color included in BLUIColors
+        label: BLUIColors.green[700],
+    },
+    bucketGauge: {
+        alarm: BLUIColors.red[500],
+        warning: BLUIColors.yellow[500],
+        test: BLUIColors.black[500],
+        healthy: BLUIColors.green[700],
+    },
+    statusCountItem: {
+        warning: BLUIColors.yellow[500],
+        //need to confirm with design team as this color variant is not defined in theme.
+        warningText: '#634107',
+        errorText: BLUIColors.white[50],
+        info: BLUIColors.black[50],
+        infoText: BLUIColors.black[500],
+    },
+};
+
+export const HmiDarkThemeColors = {
+    ...BlueDarkThemeColors,
+    warningAlternate: createSimplePalette(BLUIColors.orange),
+    scrollbar: {
+        button: BLUIColors.black[600],
+    },
+    statusBar: {
+        default: BLUIColors.darkBlack[800],
+        alarm: BLUIColors.red[900],
+        warning: BLUIColors.gold[700],
+        success: BLUIColors.green[500],
+        primary: BLUIColors.blue[700],
+    },
+    gauge: {
+        progress: BLUIColors.green[500],
+        track: Color(BLUIColors.green[500]).alpha(0.2).string(),
+        label: BLUIColors.green[500],
+    },
+    bucketGauge: {
+        alarm: BLUIColors.red[500],
+        warning: BLUIColors.yellow[600],
+        test: BLUIColors.white[50],
+        healthy: BLUIColors.green[500],
+    },
+    statusCountItem: {
+        warning: BLUIColors.yellow[600],
+        warningText: '#634107',
+        errorText: BLUIColors.white[50],
+        info: BLUIColors.black[700],
+        infoText: BLUIColors.black[100],
+    },
+};

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiAppBar.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiAppBar.ts
@@ -1,0 +1,40 @@
+import { Theme, CssVarsTheme, Components } from '@mui/material/styles';
+import * as BLUIColors from '@brightlayer-ui/colors';
+
+export default {
+    styleOverrides: {
+        root: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                backgroundImage: 'none',
+            }),
+        }),
+        colorDefault: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.background.paper,
+            color: theme.vars.palette.text.primary,
+            ...theme.applyStyles('dark', {
+                color: theme.vars.palette.text.primary,
+                backgroundColor: BLUIColors.darkBlack[100],
+            }),
+        }),
+        colorPrimary: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                color: theme.vars.palette.text.primary,
+                backgroundColor: BLUIColors.black[800],
+            }),
+        }),
+        colorSecondary: ({ theme }) => ({
+            color: theme.vars.palette.background.paper,
+            backgroundColor: theme.vars.palette.primary.dark,
+            '& .MuiInputBase-root': {
+                color: theme.vars.palette.background.paper,
+            },
+            '& .MuiSelect-icon': {
+                color: theme.vars.palette.background.paper,
+            },
+            ...theme.applyStyles('dark', {
+                color: theme.vars.palette.text.primary,
+                backgroundColor: theme.vars.palette.background.paper,
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiAppBar'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiAvatar.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiAvatar.ts
@@ -1,0 +1,17 @@
+import { Components, CssVarsTheme, Theme } from '@mui/material/styles';
+import baseOverride from '../../componentStylesOverrides/MuiAvatar';
+
+export default {
+    ...baseOverride,
+    styleOverrides: {
+        ...baseOverride?.styleOverrides,
+        root: {
+            width: 'var(--blui-avatar-size)',
+            height: 'var(--blui-avatar-size)',
+            fontSize: 'var(--blui-avatar-text)',
+            '& .MuiAvatar-icon': {
+                fontSize: 'var(--blui-avatar-icon)',
+            },
+        },
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiAvatar'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiBottomNavigation.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiBottomNavigation.ts
@@ -1,0 +1,13 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import * as BLUIColors from '@brightlayer-ui/colors';
+
+export default {
+    styleOverrides: {
+        root: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.primary.main,
+            ...theme.applyStyles('dark', {
+                backgroundColor: BLUIColors.black[800],
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiBottomNavigation'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiButton.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiButton.ts
@@ -1,0 +1,379 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import * as BLUIColors from '@brightlayer-ui/colors';
+import Color from 'color';
+
+export default {
+    styleOverrides: {
+        root: ({ theme }) => ({
+            textTransform: 'none',
+            height: 'var(--blui-button-height)',
+            borderRadius: 'var(--blui-button-radius)',
+            padding: `0 var(--blui-button-padding)`,
+            fontSize: 'var(--blui-button-text)',
+            display: 'flex',
+            gap: '8px',
+            ...theme.applyStyles('dark', {
+                textTransform: 'none',
+                '&:hover': {
+                    backgroundColor: BLUIColors.black[400],
+                },
+            }),
+        }),
+        iconSizeMedium: ({ theme }) => ({
+            '& > *:nth-of-type(1)': {
+                fontSize: 'var(--blui-button-icon)',
+            },
+            ...theme.applyStyles('dark', {
+                '& > *:nth-of-type(1)': {
+                    fontSize: 'var(--blui-button-icon)',
+                },
+            }),
+        }),
+        contained: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.background.paper,
+            color: theme.vars.palette.text.primary,
+            '& .MuiButton-disableElevation:not(.MuiButton-containedPrimary):not(.MuiButton-containedSecondary)': {
+                backgroundColor: BLUIColors.white[500],
+                '&:hover': {
+                    backgroundColor: BLUIColors.white[300],
+                },
+                '&.Mui-disabled': {
+                    borderWidth: 'var(--blui-disabled-button-border-width)',
+                },
+            },
+            '&:hover': {
+                backgroundColor: Color(BLUIColors.black[500]).alpha(0.05).string(),
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.background.paper,
+                border: `1px solid ${Color(BLUIColors.black[500]).alpha(0.12).string()}`,
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: BLUIColors.black[500],
+                color: BLUIColors.white[50],
+                '&:hover': {
+                    backgroundColor: BLUIColors.black[400],
+                },
+                '&.Mui-disabled': {
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: BLUIColors.black[400],
+                },
+            }),
+        }),
+        containedPrimary: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.primary.main,
+            color: BLUIColors.white[50],
+            '&:hover': {
+                backgroundColor: BLUIColors.blue[300],
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.primary.light,
+                borderWidth: 'var(--blui-disabled-button-border-width)',
+                color: BLUIColors.blue[200],
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.primary.dark,
+                color: BLUIColors.white[50],
+                '&:hover': {
+                    backgroundColor: BLUIColors.blue[300],
+                },
+                '&.Mui-disabled': {
+                    borderWidth: 'var(--blui-disabled-button-border-width)',
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: BLUIColors.black[400],
+                },
+            }),
+        }),
+        containedSecondary: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.secondary.main,
+            color: BLUIColors.white[50],
+            '&:hover': {
+                backgroundColor: BLUIColors.lightBlue[300],
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.primary.light,
+                borderWidth: 'var(--blui-disabled-button-border-width)',
+                color: BLUIColors.blue[200],
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.secondary.dark,
+                color: BLUIColors.white[50],
+                '&:hover': {
+                    backgroundColor: BLUIColors.lightBlue[300],
+                },
+                '&.Mui-disabled': {
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: BLUIColors.black[400],
+                },
+            }),
+        }),
+        containedSuccess: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.success.main,
+            color: BLUIColors.white[50],
+            '&:hover': {
+                backgroundColor: theme.vars.palette.success.dark,
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.success.light,
+                color: theme.vars.palette.action.disabled,
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.success.dark,
+                color: BLUIColors.white[50],
+                '&:hover': {
+                    backgroundColor: theme.vars.palette.success.main,
+                },
+                '&.Mui-disabled': {
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: theme.vars.palette.action.disabled,
+                },
+            }),
+        }),
+        containedWarning: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.warning.main,
+            color: theme.vars.palette.warning.contrastText ?? '#fff',
+            '&:hover': {
+                backgroundColor: theme.vars.palette.warning.dark,
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.warning.light,
+                color: theme.vars.palette.action.disabled,
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.warning.dark,
+                color: theme.vars.palette.warning.contrastText ?? '#fff',
+                '&:hover': {
+                    backgroundColor: theme.vars.palette.warning.main,
+                },
+                '&.Mui-disabled': {
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: theme.vars.palette.action.disabled,
+                },
+            }),
+        }),
+        containedError: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.error.main,
+            color: BLUIColors.white[50],
+            '&:hover': {
+                backgroundColor: theme.vars.palette.error.dark,
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.error.light,
+                color: theme.vars.palette.action.disabled,
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.error.dark,
+                color: BLUIColors.white[50],
+                '&:hover': {
+                    backgroundColor: theme.vars.palette.error.main,
+                },
+                '&.Mui-disabled': {
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: theme.vars.palette.action.disabled,
+                },
+            }),
+        }),
+        containedInfo: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.info.main,
+            color: BLUIColors.white[50],
+            '&:hover': {
+                backgroundColor: theme.vars.palette.info.dark,
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.info.light,
+                color: theme.vars.palette.action.disabled,
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.info.dark,
+                color: BLUIColors.white[50],
+                '&:hover': {
+                    backgroundColor: theme.vars.palette.info.main,
+                },
+                '&.Mui-disabled': {
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: theme.vars.palette.action.disabled,
+                },
+            }),
+        }),
+        containedAlternateWarning: ({ theme }: { theme: Theme & CssVarsTheme }) => ({
+            backgroundColor: theme.vars.palette.warningAlternate.main,
+            color: BLUIColors.white[50],
+            '&:hover': {
+                backgroundColor: theme.vars.palette.warningAlternate.dark,
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.warningAlternate.light,
+                color: theme.vars.palette.action.disabled,
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.warningAlternate.dark,
+                color: BLUIColors.white[50],
+                '&:hover': {
+                    backgroundColor: theme.vars.palette.warningAlternate.main,
+                },
+                '&.Mui-disabled': {
+                    backgroundColor: theme.vars.palette.action.disabledBackground,
+                    color: theme.vars.palette.action.disabled,
+                },
+            }),
+        }),
+        outlinedAlternateWarning: ({ theme }: { theme: Theme & CssVarsTheme }) => ({
+            borderColor: theme.vars.palette.warningAlternate.main,
+            color: theme.vars.palette.warningAlternate.main,
+            '&:hover': {
+                backgroundColor: `rgba(${theme.vars.palette.warningAlternate.main} / 0.05)`,
+            },
+            '&.Mui-disabled': {
+                borderColor: theme.vars.palette.warningAlternate.light,
+                color: theme.vars.palette.action.disabled,
+            },
+            ...theme.applyStyles('dark', {
+                borderColor: theme.vars.palette.warningAlternate.dark,
+                color: theme.vars.palette.warningAlternate.dark,
+                '&:hover': {
+                    backgroundColor: `rgba(${theme.vars.palette.warningAlternate.dark} / 0.2)`,
+                },
+                '&.Mui-disabled': {
+                    borderColor: theme.vars.palette.action.disabledBackground,
+                    color: theme.vars.palette.action.disabled,
+                },
+            }),
+        }),
+        textAlternateWarning: ({ theme }: { theme: Theme & CssVarsTheme }) => ({
+            color: theme.vars.palette.warningAlternate.main,
+            '&:hover': {
+                backgroundColor: `rgba(${theme.vars.palette.warningAlternate.main} / 0.05)`,
+            },
+            '&.Mui-disabled': {
+                color: theme.vars.palette.action.disabled,
+            },
+            ...theme.applyStyles('dark', {
+                color: theme.vars.palette.warningAlternate.dark,
+                '&:hover': {
+                    backgroundColor: `rgba(${theme.vars.palette.warningAlternate.dark} / 0.2)`,
+                },
+                '&.Mui-disabled': {
+                    color: theme.vars.palette.action.disabled,
+                },
+            }),
+        }),
+        outlined: ({ theme }) => ({
+            '&:hover': {
+                backgroundColor: Color(BLUIColors.black[500]).alpha(0.05).string(),
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.background.paper,
+                borderColor: Color(BLUIColors.black[500]).alpha(0.12).string(),
+            },
+            ...theme.applyStyles('dark', {
+                '&:hover': {
+                    backgroundColor: Color(BLUIColors.black[50]).alpha(0.1).string(),
+                },
+                '&.Mui-disabled': {
+                    borderColor: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    color: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    backgroundColor: 'transparent',
+                },
+            }),
+        }),
+        outlinedInherit: ({ theme }) => ({
+            borderColor: theme.vars.palette.divider,
+            '&:hover': {
+                backgroundColor: Color(BLUIColors.black[500]).alpha(0.05).string(),
+            },
+            '&.Mui-disabled': {
+                backgroundColor: theme.vars.palette.background.paper,
+                borderColor: Color(BLUIColors.black[500]).alpha(0.12).string(),
+            },
+            ...theme.applyStyles('dark', {
+                borderColor: BLUIColors.black[200],
+                '&:hover': {
+                    backgroundColor: Color(BLUIColors.black[50]).alpha(0.1).string(),
+                },
+                '&.Mui-disabled': {
+                    borderColor: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    color: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    backgroundColor: 'transparent',
+                },
+            }),
+        }),
+        outlinedPrimary: ({ theme }) => ({
+            borderColor: theme.vars.palette.primary.main,
+            '&.Mui-disabled': {
+                borderColor: Color(BLUIColors.black[500]).alpha(0.12).string(),
+            },
+            '&:hover': {
+                backgroundColor: `rgba(${theme.vars.palette.primary.main} / 0.05)`,
+            },
+            ...theme.applyStyles('dark', {
+                borderColor: theme.vars.palette.primary.main,
+                '&:hover': {
+                    backgroundColor: `rgba(${theme.vars.palette.primary.dark} / 0.2)`,
+                },
+                '&.Mui-disabled': {
+                    borderColor: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    color: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    backgroundColor: 'transparent',
+                },
+            }),
+        }),
+        outlinedSecondary: ({ theme }) => ({
+            borderColor: theme.vars.palette.secondary.main,
+            '&.Mui-disabled': {
+                borderColor: Color(BLUIColors.black[500]).alpha(0.12).string(),
+            },
+            '&:hover': {
+                backgroundColor: `rgba(${theme.vars.palette.secondary.main} / 0.05)`,
+            },
+            ...theme.applyStyles('dark', {
+                '&:not(.Mui-disabled)': {
+                    borderColor: theme.vars.palette.secondary.main,
+                    '&:hover': {
+                        backgroundColor: `rgba(${theme.vars.palette.secondary.dark} / 0.2)`,
+                    },
+                },
+                '&.Mui-disabled': {
+                    borderColor: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    color: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    backgroundColor: 'transparent',
+                },
+            }),
+        }),
+        text: ({ theme }) => ({
+            '&.Mui-disabled': {
+                color: theme.vars.palette.action.disabled,
+            },
+            '&:hover': {
+                backgroundColor: Color(BLUIColors.black[500]).alpha(0.05).string(),
+            },
+            ...theme.applyStyles('dark', {
+                '&.Mui-disabled': {
+                    color: theme.vars.palette.action.disabled,
+                },
+                '&:hover': {
+                    backgroundColor: theme.vars.palette.action.hover,
+                },
+            }),
+        }),
+        textPrimary: ({ theme }) => ({
+            '&:hover': {
+                backgroundColor: `rgba(${theme.vars.palette.primary.main} / 0.05)`,
+            },
+            ...theme.applyStyles('dark', {
+                '&:hover': {
+                    backgroundColor: `rgba(${theme.vars.palette.primary.dark} / 0.2)`,
+                },
+            }),
+        }),
+        textSecondary: ({ theme }) => ({
+            '&:hover': {
+                backgroundColor: `rgba(${theme.vars.palette.secondary.main} / 0.05)`,
+            },
+            ...theme.applyStyles('dark', {
+                '&:hover': {
+                    backgroundColor: `rgba(${theme.vars.palette.secondary.dark} / 0.2)`,
+                },
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiButton'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiCard.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiCard.ts
@@ -1,0 +1,20 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+
+export default {
+    styleOverrides: {
+        root: {
+            borderRadius: 'var(--blui-card-radius)',
+        },
+        header: {
+            minHeight: 'var(--blui-card-header-footer)',
+            fontSize: 'var(--blui-card-header-foot-text)',
+        },
+        footer: {
+            minHeight: 'var(--blui-card-header-footer)',
+            fontSize: 'var(--blui-card-header-foot-text)',
+        },
+        icon: {
+            fontSize: 'var(--blui-card-header-footer-icon)',
+        },
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiCard'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiChip.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiChip.ts
@@ -1,0 +1,465 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import * as BLUIColors from '@brightlayer-ui/colors';
+import Color from 'color';
+
+const WhiteText = BLUIColors.white[50];
+const Spacing = 8;
+const BlackBorder = BLUIColors.black[500];
+
+export default {
+    styleOverrides: {
+        root: ({ theme }) => ({
+            fontSize: 'var(--blui-chip-avatar-text, 0.875rem)',
+            borderRadius: 'var(--blui-chip-radius, 160px)',
+            backgroundColor: BLUIColors.white[500],
+            color: theme.vars.palette.text.primary,
+            minHeight: 'var(--blui-chip-height, 32px)',
+            justifyContent: 'center',
+            alignItems: 'center',
+            display: 'inline-flex',
+            '& .MuiChip-avatar': {
+                backgroundColor: theme.vars.palette.primary.main,
+                color: BLUIColors.white[50],
+                marginRight: -4,
+                width: 'var(--blui-chip-avatar, 24px)',
+                height: 'var(--blui-chip-avatar, 24px)',
+                fontSize: 'var(--blui-chip-avatar-text, 10px)',
+                borderRadius: 'var(--blui-chip-avatar-radius, 200px)',
+            },
+            '& .MuiChip-avatarColorPrimary': {
+                backgroundColor: theme.vars.palette.primary.light,
+                color: theme.vars.palette.primary.main,
+            },
+            '& .MuiChip-avatarColorSecondary': {
+                backgroundColor: theme.vars.palette.primary.light,
+                color: theme.vars.palette.primary.main,
+            },
+            '&.Mui-disabled': {
+                opacity: 1,
+                color: theme.vars.palette.action.disabled,
+                '& .MuiChip-avatar': {
+                    opacity: 0.5,
+                },
+                '&:not(.MuiChip-colorPrimary):not(.MuiChip-colorSecondary) .MuiChip-deleteIcon': {
+                    color: theme.vars.palette.action.disabled,
+                },
+                '&:not(.MuiChip-colorPrimary):not(.MuiChip-colorSecondary) .MuiChip-icon': {
+                    color: theme.vars.palette.action.disabled,
+                },
+            },
+            ...theme.applyStyles('dark', {
+                fontSize: '0.875rem',
+                backgroundColor: BLUIColors.black[500],
+                color: theme.vars.palette.text.primary,
+                '& .MuiChip-avatar': {
+                    backgroundColor: BLUIColors.black[700],
+                    color: theme.vars.palette.text.primary,
+                    marginRight: -4,
+                },
+                '& .MuiChip-avatarColorPrimary': {
+                    backgroundColor: theme.vars.palette.primary.light,
+                    color: theme.vars.palette.primary.dark,
+                },
+                '& .MuiChip-avatarColorSecondary': {
+                    backgroundColor: theme.vars.palette.primary.light,
+                    color: theme.vars.palette.primary.dark,
+                },
+                '&.Mui-disabled': {
+                    opacity: 1,
+                    backgroundColor: Color(BLUIColors.black[200]).alpha(0.24).string(),
+                    color: BLUIColors.black[400],
+                    '& .MuiChip-avatar': {
+                        opacity: 0.5,
+                    },
+                    '& .MuiChip-deleteIcon': {
+                        color: theme.vars.palette.action.disabled,
+                    },
+                    '& .MuiChip-icon': {
+                        color: theme.vars.palette.action.disabled,
+                    },
+                },
+            }),
+        }),
+        clickable: ({ theme }) => ({
+            '&:hover': {
+                backgroundColor: BLUIColors.gray[100],
+            },
+            '&.MuiChip-clickableColorPrimary': {
+                '&:hover': {
+                    backgroundColor: BLUIColors.blue[300],
+                },
+            },
+            '&.MuiChip-clickableColorSecondary': {
+                '&:hover': {
+                    backgroundColor: BLUIColors.lightBlue[300],
+                },
+            },
+            ...theme.applyStyles('dark', {
+                '&:hover': {
+                    backgroundColor: BLUIColors.black[400],
+                },
+                '&.MuiChip-clickableColorPrimary': {
+                    '&:hover': {
+                        backgroundColor: BLUIColors.blue[300],
+                    },
+                },
+                '&.MuiChip-clickableColorSecondary': {
+                    '&:hover': {
+                        backgroundColor: BLUIColors.lightBlue[300],
+                    },
+                },
+            }),
+        }),
+        colorPrimary: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.primary.main,
+            color: WhiteText,
+            '&:not(.MuiChip-outlinedPrimary).Mui-disabled': {
+                backgroundColor: theme.vars.palette.primary.light,
+                color: BLUIColors.blue[200],
+                opacity: 1,
+            },
+            ...theme.applyStyles('dark', {
+                color: WhiteText,
+                backgroundColor: theme.vars.palette.primary.dark,
+                '&:not(.MuiChip-outlinedPrimary).Mui-disabled': {
+                    backgroundColor: theme.vars.palette.divider,
+                    color: BLUIColors.black[300],
+                    opacity: 0.8,
+                },
+            }),
+        }),
+        colorSecondary: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.secondary.main,
+            color: WhiteText,
+            '&:not(.MuiChip-outlinedSecondary).Mui-disabled': {
+                backgroundColor: theme.vars.palette.secondary.light,
+                color: BLUIColors.lightBlue[200],
+                opacity: 0.8,
+            },
+            ...theme.applyStyles('dark', {
+                color: WhiteText,
+                backgroundColor: theme.vars.palette.secondary.dark,
+                '&:not(.MuiChip-outlinedSecondary).Mui-disabled': {
+                    backgroundColor: theme.vars.palette.divider,
+                    color: BLUIColors.black[300],
+                    opacity: 0.8,
+                },
+            }),
+        }),
+        colorSuccess: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.success.main,
+            color: BLUIColors.white[50],
+            '&:not(.MuiChip-outlinedSuccess).Mui-disabled': {
+                backgroundColor: theme.vars.palette.success.light,
+                color: BLUIColors.green[200],
+                opacity: 1,
+            },
+            ...theme.applyStyles('dark', {
+                color: BLUIColors.white[50],
+                backgroundColor: theme.vars.palette.success.dark,
+                '&:not(.MuiChip-outlinedSuccess).Mui-disabled': {
+                    backgroundColor: theme.vars.palette.divider,
+                    color: BLUIColors.black[300],
+                    opacity: 0.8,
+                },
+            }),
+        }),
+        colorError: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.error.main,
+            color: BLUIColors.white[50],
+            '&:not(.MuiChip-outlinedError).Mui-disabled': {
+                backgroundColor: theme.vars.palette.error.light,
+                color: BLUIColors.red[200],
+                opacity: 1,
+            },
+            ...theme.applyStyles('dark', {
+                color: BLUIColors.white[50],
+                backgroundColor: theme.vars.palette.error.dark,
+                '&:not(.MuiChip-outlinedError).Mui-disabled': {
+                    backgroundColor: theme.vars.palette.divider,
+                    color: BLUIColors.black[300],
+                    opacity: 0.8,
+                },
+            }),
+        }),
+        colorInfo: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.info.main,
+            color: BLUIColors.white[50],
+            '&:not(.MuiChip-outlinedInfo).Mui-disabled': {
+                backgroundColor: theme.vars.palette.info.light,
+                color: BLUIColors.lightBlue[200],
+                opacity: 1,
+            },
+            ...theme.applyStyles('dark', {
+                color: BLUIColors.white[50],
+                backgroundColor: theme.vars.palette.info.dark,
+                '&:not(.MuiChip-outlinedInfo).Mui-disabled': {
+                    backgroundColor: theme.vars.palette.divider,
+                    color: BLUIColors.black[300],
+                    opacity: 0.8,
+                },
+            }),
+        }),
+        colorWarning: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.warning.main,
+            color: BLUIColors.white[50],
+            '&:not(.MuiChip-outlinedWarning).Mui-disabled': {
+                backgroundColor: theme.vars.palette.warning.light,
+                color: BLUIColors.yellow[200],
+                opacity: 1,
+            },
+            ...theme.applyStyles('dark', {
+                color: BLUIColors.white[50],
+                backgroundColor: theme.vars.palette.warning.dark,
+                '&:not(.MuiChip-outlinedWarning).Mui-disabled': {
+                    backgroundColor: theme.vars.palette.divider,
+                    color: BLUIColors.black[300],
+                    opacity: 0.8,
+                },
+            }),
+        }),
+        colorAlternateWarning: ({ theme }: { theme: Theme & CssVarsTheme }) => ({
+            backgroundColor: theme.vars.palette.warningAlternate.main,
+            color: BLUIColors.white[50],
+            '&:not(.MuiChip-outlinedAlternateWarning).Mui-disabled': {
+                backgroundColor: theme.vars.palette.warningAlternate.light,
+                color: BLUIColors.orange[200],
+                opacity: 1,
+            },
+            ...theme.applyStyles('dark', {
+                color: BLUIColors.white[50],
+                backgroundColor: theme.vars.palette.warningAlternate.dark,
+                '&:not(.MuiChip-outlinedAlternateWarning).Mui-disabled': {
+                    backgroundColor: theme.vars.palette.divider,
+                    color: BLUIColors.black[300],
+                    opacity: 0.8,
+                },
+            }),
+        }),
+        deleteIcon: ({ theme }) => ({
+            fontSize: 'var(--blui-chip-icon, 1.125rem)',
+            height: 'var(--blui-chip-icon, 1.125rem)',
+            width: 'var(--blui-chip-icon, 1.125rem)',
+            margin: `0px ${Spacing}px 0px -4px`,
+            color: theme.vars.palette.action.active,
+            '&:hover': {
+                color: theme.vars.palette.text.primary,
+            },
+            '&.MuiChip-deleteIconColorPrimary': {
+                color: BLUIColors.blue[100],
+                '&:hover': {
+                    color: WhiteText,
+                },
+            },
+            '&.MuiChip-deleteIconColorSecondary': {
+                color: BLUIColors.lightBlue[100],
+                '&:hover': {
+                    color: WhiteText,
+                },
+            },
+            ...theme.applyStyles('dark', {
+                fontSize: '1.125rem',
+                height: '1.125rem',
+                width: '1.125rem',
+                margin: `0px ${Spacing}px 0px -4px`,
+                color: theme.vars.palette.text.secondary,
+                '&:hover': {
+                    color: theme.vars.palette.text.primary,
+                },
+                '&.MuiChip-deleteIconColorPrimary': {
+                    color: BLUIColors.blue[100],
+                    '&:hover': {
+                        color: WhiteText,
+                    },
+                },
+                '&.MuiChip-deleteIconColorSecondary': {
+                    color: BLUIColors.lightBlue[100],
+                    '&:hover': {
+                        color: WhiteText,
+                    },
+                },
+            }),
+        }),
+        iconColorPrimary: ({ theme }) => ({
+            ...theme.applyStyles('light', {
+                color: 'inherit',
+            }),
+        }),
+        iconColorSecondary: ({ theme }) => ({
+            ...theme.applyStyles('light', {
+                color: 'inherit',
+            }),
+        }),
+        outlined: ({ theme }) => ({
+            borderRadius: 'var(--blui-chip-radius, 160px)',
+            backgroundColor: 'transparent',
+            '&.MuiChip-clickable:hover': {
+                backgroundColor: BLUIColors.white[200],
+            },
+            '& .MuiChip-avatar': {
+                backgroundColor: BLUIColors.gray[500],
+                marginRight: -4,
+                width: 'var(--blui-chip-avatar, 24px)',
+                height: 'var(--blui-chip-avatar, 24px)',
+                fontSize: 'var(--blui-chip-avatar-text, 10px)',
+            },
+            '& .MuiChip-avatarColorPrimary': {
+                backgroundColor: BLUIColors.blue[100],
+                color: theme.vars.palette.primary.main,
+            },
+            '& .MuiChip-avatarColorSecondary': {
+                backgroundColor: BLUIColors.blue[100],
+                color: theme.vars.palette.primary.main,
+            },
+            '& .MuiChip-icon': {
+                marginLeft: Spacing,
+                marginRight: -4,
+            },
+            '& .MuiChip-deleteIcon': {
+                margin: `0px ${Spacing}px 0px -4px`,
+            },
+            '&.Mui-disabled .MuiChip-deleteIcon': {
+                color: 'inherit',
+            },
+            '&.MuiChip-outlinedPrimary': {
+                backgroundColor: `rgba(${theme.vars.palette.primary.main} / 0.05)`,
+                border: `1px solid ${theme.vars.palette.primary.main}`,
+                color: theme.vars.palette.primary.main,
+                '&.MuiChip-clickable:hover': {
+                    backgroundColor: `rgba(${theme.vars.palette.primary.main} / 0.1)`,
+                },
+                '&.Mui-disabled': {
+                    opacity: 1,
+                    backgroundColor: theme.vars.palette.background.paper,
+                    color: theme.vars.palette.action.disabled,
+                    borderColor: Color(BlackBorder).alpha(0.12).string(),
+                },
+                '& .MuiChip-deleteIconOutlinedColorPrimary': {
+                    '&:hover': {
+                        color: theme.vars.palette.primary.main,
+                    },
+                },
+            },
+            '&.MuiChip-outlinedSecondary': {
+                backgroundColor: `rgba(${theme.vars.palette.secondary.main} / 0.05)`,
+                border: `1px solid ${theme.vars.palette.secondary.main}`,
+                color: theme.vars.palette.secondary.main,
+                '&.MuiChip-clickable:hover': {
+                    backgroundColor: `rgba(${theme.vars.palette.secondary.main} / 0.1)`,
+                },
+                '&.Mui-disabled': {
+                    opacity: 1,
+                    backgroundColor: theme.vars.palette.background.paper,
+                    color: theme.vars.palette.action.disabled,
+                    borderColor: Color(BlackBorder).alpha(0.12).string(),
+                },
+                '& .MuiChip-deleteIconOutlinedColorSecondary': {
+                    '&:hover': {
+                        color: theme.vars.palette.secondary.main,
+                    },
+                },
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.background.paper,
+                borderColor: Color(BLUIColors.black[200]).alpha(0.32).string(),
+                '&.MuiChip-clickable:hover': {
+                    backgroundColor: BLUIColors.black[800],
+                },
+                '& .MuiChip-avatar': {
+                    backgroundColor: BLUIColors.black[600],
+                    color: theme.vars.palette.text.primary,
+                    marginRight: -4,
+                },
+                '& .MuiChip-avatarColorPrimary': {
+                    backgroundColor: BLUIColors.blue[100],
+                    color: theme.vars.palette.primary.dark,
+                },
+                '& .MuiChip-avatarColorSecondary': {
+                    backgroundColor: BLUIColors.blue[100],
+                    color: theme.vars.palette.primary.dark,
+                },
+                '& .MuiChip-icon': {
+                    marginLeft: Spacing,
+                    marginRight: -4,
+                },
+                '& .MuiChip-deleteIcon': {
+                    margin: `0px ${Spacing}px 0px -4px`,
+                },
+                '&.Mui-disabled .MuiChip-deleteIcon': {
+                    color: 'inherit',
+                },
+                '&.Mui-disabled': {
+                    opacity: 1,
+                    borderColor: Color(BLUIColors.black[200]).alpha(0.36).string(),
+                    backgroundColor: 'transparent',
+                    color: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                    '& .MuiChip-deleteIconOutlinedColorPrimary': {
+                        color: 'inherit',
+                    },
+                },
+                '&.MuiChip-outlinedPrimary': {
+                    backgroundColor: Color(BLUIColors.blue[400]).alpha(0.2).string(),
+                    border: `1px solid ${theme.vars.palette.primary.main}`,
+
+                    color: theme.vars.palette.primary.main,
+                    '&.MuiChip-clickable:hover': {
+                        backgroundColor: Color(BLUIColors.blue[500]).alpha(0.4).string(),
+                    },
+                    '& .MuiChip-deleteIconOutlinedColorPrimary': {
+                        color: BLUIColors.blue[400],
+                        '&:hover': {
+                            color: theme.vars.palette.primary.main,
+                        },
+                    },
+                    '&.Mui-disabled': {
+                        opacity: 1,
+                        borderColor: Color(BLUIColors.black[200]).alpha(0.36).string(),
+                        backgroundColor: 'transparent',
+                        color: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                        '& .MuiChip-deleteIconOutlinedColorPrimary': {
+                            color: 'inherit',
+                        },
+                    },
+                },
+                '&.MuiChip-outlinedSecondary': {
+                    backgroundColor: Color(BLUIColors.blue[300]).alpha(0.25).string(),
+                    border: `1px solid ${theme.vars.palette.secondary.main}`,
+                    color: theme.vars.palette.secondary.main,
+                    '&.MuiChip-clickable:hover': {
+                        backgroundColor: Color(BLUIColors.blue[600]).alpha(0.4).string(),
+                    },
+                    '& .MuiChip-deleteIconOutlinedColorSecondary': {
+                        color: BLUIColors.lightBlue[400],
+                        '&:hover': {
+                            color: theme.vars.palette.secondary.main,
+                        },
+                    },
+                    '&.Mui-disabled': {
+                        opacity: 1,
+                        backgroundColor: 'transparent',
+                        color: Color(BLUIColors.black[300]).alpha(0.36).string(),
+                        borderColor: Color(BLUIColors.black[200]).alpha(0.36).string(),
+                        '& .MuiChip-deleteIconOutlinedColorSecondary': {
+                            color: 'inherit',
+                        },
+                    },
+                },
+            }),
+        }),
+        icon: ({ theme }) => ({
+            fontSize: 'var(--blui-chip-icon, 1.125rem)',
+            ...theme.applyStyles('light', {
+                fontSize: 'var(--blui-chip-icon, 1.125rem)',
+                color: theme.vars.palette.text.primary,
+                marginLeft: Spacing,
+                marginRight: -4,
+            }),
+            ...theme.applyStyles('dark', {
+                fontSize: 'var(--blui-chip-icon, 1.125rem)',
+                color: theme.vars.palette.text.primary,
+                marginLeft: Spacing,
+                marginRight: -4,
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiChip'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiCircularProgress.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiCircularProgress.ts
@@ -1,0 +1,17 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import baseOverride from '../../componentStylesOverrides/MuiCircularProgress';
+
+export default {
+    ...baseOverride,
+    styleOverrides: {
+        ...baseOverride!.styleOverrides,
+        root: {
+            width: 'var(--blui-ring-chart-size)',
+            height: 'var(--blui-ring-chart-size)',
+        },
+        svg: {
+            width: 'var(--blui-ring-chart-size)',
+            height: 'var(--blui-ring-chart-size)',
+        },
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiCircularProgress'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiDrawer.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiDrawer.ts
@@ -1,0 +1,17 @@
+import { BLUIColors } from '@brightlayer-ui/colors';
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+
+export default {
+    styleOverrides: {
+        paper: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                backgroundColor: BLUIColors.darkBlack[300],
+            }),
+        }),
+        paperAnchorBottom: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.background.paper,
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiDrawer'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiFilledInput.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiFilledInput.ts
@@ -1,0 +1,85 @@
+import { BLUIColors } from '@brightlayer-ui/colors';
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import Color from 'color';
+
+export default {
+    styleOverrides: {
+        root: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.background.default,
+            '&:hover': {
+                '@media (hover: none)': {
+                    backgroundColor: BLUIColors.white[400],
+                },
+                backgroundColor: BLUIColors.white[400],
+            },
+            '&.Mui-focused': {
+                backgroundColor: theme.vars.palette.background.default,
+            },
+            '&.Mui-disabled': {
+                color: `rgba(${theme.vars.palette.text.primary} / 0.3)`,
+                backgroundColor: BLUIColors.white[100],
+                pointerEvents: 'none',
+            },
+            ...theme.applyStyles('dark', {
+                backgroundColor: BLUIColors.black[800],
+                '&:hover': {
+                    backgroundColor: BLUIColors.black[600],
+                },
+                '&.Mui-focused': {
+                    backgroundColor: BLUIColors.black[800],
+                },
+                '&.Mui-disabled': {
+                    color: theme.vars.palette.text.disabled,
+                    backgroundColor: Color(BLUIColors.black[800]).alpha(0.5).string(),
+                    pointerEvents: 'none',
+                },
+            }),
+        }),
+        input: ({ theme }) => ({
+            '&:-webkit-autofill': {
+                WebkitBoxShadow: `0 0 0 30px ${theme.vars.palette.background.default} inset`,
+            },
+            ...theme.applyStyles('dark', {
+                '&:-webkit-autofill': {
+                    WebkitBoxShadow: `0 0 0 100px ${BLUIColors.black[800]} inset`,
+                },
+            }),
+        }),
+        underline: ({ theme }) => ({
+            '&:before': {
+                borderBottomColor: theme.vars.palette.divider,
+            },
+            '&.Mui-error:not(.Mui-focused):after': {
+                borderBottomWidth: 1,
+            },
+            '&.Mui-disabled:before': {
+                borderBottomColor: theme.vars.palette.divider,
+                borderBottomStyle: 'solid',
+            },
+            ...theme.applyStyles('dark', {
+                '&:before': {
+                    borderBottomColor: theme.vars.palette.divider,
+                },
+                '&:after': {
+                    borderBottomColor: theme.vars.palette.primary.dark,
+                },
+                '&.Mui-error.Mui-focused:after': {
+                    borderBottomColor: theme.vars.palette.error.dark,
+                },
+                '&.Mui-error:not(.Mui-focused):after': {
+                    borderBottomWidth: 1,
+                    borderBottomColor: theme.vars.palette.error.dark,
+                },
+                '&.Mui-error:not(.Mui-focused):hover:after': {
+                    borderBottomColor: theme.vars.palette.error.main,
+                },
+                '&.Mui-disabled:before': {
+                    borderBottomStyle: 'solid',
+                },
+                '&.MuiFilledInput-colorSecondary:not(.Mui-error):after': {
+                    borderBottomColor: theme.vars.palette.secondary.dark,
+                },
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiFilledInput'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiFormHelperText.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiFormHelperText.ts
@@ -1,0 +1,18 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import baseOverride from '../../componentStylesOverrides/MuiFormHelperText';
+
+const baseRoot = baseOverride!.styleOverrides!.root as (args: any) => object;
+
+export default {
+    ...baseOverride,
+    styleOverrides: {
+        ...baseOverride!.styleOverrides,
+        root: (args: Parameters<typeof baseRoot>[0]) => ({
+            fontSize: 'var(--blui-caption-font-size, 18px)',
+            fontStyle: 'normal',
+            fontWeight: 400,
+            lineHeight: 'normal',
+            ...baseRoot(args),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiFormHelperText'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiFormLabel.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiFormLabel.ts
@@ -1,0 +1,18 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import baseOverride from '../../componentStylesOverrides/MuiFormLabel';
+
+const baseRoot = baseOverride!.styleOverrides!.root as (args: any) => object;
+
+export default {
+    ...baseOverride,
+    styleOverrides: {
+        ...baseOverride!.styleOverrides,
+        root: (args: Parameters<typeof baseRoot>[0]) => ({
+            fontSize: 'var(--blui-caption-font-size, 18px)',
+            fontStyle: 'normal',
+            fontWeight: 400,
+            lineHeight: 1,
+            ...baseRoot(args),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiFormLabel'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiInputBase.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiInputBase.ts
@@ -1,0 +1,25 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import baseOverride from '../../componentStylesOverrides/MuiInputBase';
+
+const baseRoot = baseOverride!.styleOverrides!.root as (args: any) => object;
+const baseInput = baseOverride!.styleOverrides!.input as (args: any) => object;
+
+export default {
+    ...baseOverride,
+    styleOverrides: {
+        ...baseOverride!.styleOverrides,
+        root: (args: Parameters<typeof baseRoot>[0]) => ({
+            Height: 'var(--blui-input-inner-height)',
+            borderRadius: 'var(--blui-input-radius)',
+            ...baseRoot(args),
+        }),
+        input: (args: Parameters<typeof baseInput>[0]) => ({
+            fontSize: 'var(--blui-input-text, 24px)',
+            fontStyle: 'normal',
+            fontWeight: 400,
+            lineHeight: 'normal',
+            padding: 'var(--blui-input-padding)',
+            ...baseInput(args),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiInputBase'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiInputBase.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiInputBase.ts
@@ -9,7 +9,7 @@ export default {
     styleOverrides: {
         ...baseOverride!.styleOverrides,
         root: (args: Parameters<typeof baseRoot>[0]) => ({
-            Height: 'var(--blui-input-inner-height)',
+            height: 'var(--blui-input-inner-height)',
             borderRadius: 'var(--blui-input-radius)',
             ...baseRoot(args),
         }),

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiInputLabel.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiInputLabel.ts
@@ -1,0 +1,16 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+
+export default {
+    styleOverrides: {
+        root: () => ({
+            fontSize: 'var(--blui-caption-font-size, 18px)',
+            fontStyle: 'normal',
+            fontWeight: 400,
+            lineHeight: 1,
+            transform: 'translate(16px, 24px) scale(1)',
+            '&.MuiInputLabel-shrink': {
+                transform: 'translate(12px, -1.5px) scale(0.75)',
+            },
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiInputLabel'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiLinearProgress.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiLinearProgress.ts
@@ -1,0 +1,44 @@
+import { BLUIColors } from '@brightlayer-ui/colors';
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+
+export default {
+    styleOverrides: {
+        root: {
+            height: 'var(--blui-progress-bar)',
+            borderRadius: 0,
+        },
+
+        colorPrimary: ({ theme }) => ({
+            backgroundColor: BLUIColors.blue[100],
+            ...theme.applyStyles('dark', {
+                backgroundColor: `rgba(${theme.vars.palette.primary.darkChannel} / 0.3)`,
+            }),
+        }),
+        colorSecondary: ({ theme }) => ({
+            backgroundColor: BLUIColors.lightBlue[100],
+            ...theme.applyStyles('dark', {
+                backgroundColor: `rgba(${theme.vars.palette.secondary.darkChannel} / 0.3)`,
+            }),
+        }),
+        dashedColorPrimary: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                backgroundImage: `radial-gradient(rgba(${theme.vars.palette.primary.darkChannel} / 0.5) 0%, rgba(${theme.vars.palette.primary.darkChannel} / 0.7) 16%, transparent 42%)`,
+            }),
+        }),
+        dashedColorSecondary: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                backgroundImage: `radial-gradient(rgba(${theme.vars.palette.secondary.darkChannel} / 0.5) 0%, rgba(${theme.vars.palette.secondary.darkChannel} / 0.7) 16%, transparent 42%)`,
+            }),
+        }),
+        barColorPrimary: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.primary.dark,
+            }),
+        }),
+        barColorSecondary: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.secondary.dark,
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiLinearProgress'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiRadio.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiRadio.ts
@@ -1,0 +1,30 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+
+export default {
+    styleOverrides: {
+        root: {
+            width: 'var(--blui-normal-icon, 32px)',
+            height: 'var(--blui-normal-icon, 32px)',
+            margin: '16px',
+            '& svg': {
+                width: 'var(--blui-normal-icon, 32px)',
+                height: 'var(--blui-normal-icon, 32px)',
+            },
+        },
+        colorPrimary: ({ theme }: { theme: Theme }) => ({
+            color: theme.vars.palette.primary.main,
+        }),
+        colorSecondary: ({ theme }: { theme: Theme }) => ({
+            color: theme.vars.palette.secondary.main,
+        }),
+        colorSuccess: ({ theme }: { theme: Theme }) => ({
+            color: theme.vars.palette.success.main,
+        }),
+        colorWarning: ({ theme }: { theme: Theme }) => ({
+            color: theme.vars.palette.warning.main,
+        }),
+        colorError: ({ theme }: { theme: Theme }) => ({
+            color: theme.vars.palette.error.main,
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiRadio'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiStepper.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiStepper.ts
@@ -1,0 +1,19 @@
+export default {
+    styleOverrides: {
+        root: {
+            padding: 'var(--blui-stepper-padding)',
+        },
+        dot: {
+            width: 'var(--blui-stepper-dot)',
+            height: 'var(--blui-stepper-dot)',
+        },
+        // For Linear Stepper avatars/icons:
+        avatar: {
+            width: 'var(--blui-linear-stepper-avatar)',
+            height: 'var(--blui-linear-stepper-avatar)',
+        },
+        icon: {
+            fontSize: 'var(--blui-linear-stepper-icon)',
+        },
+    },
+};

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiSwitch.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiSwitch.ts
@@ -1,0 +1,102 @@
+import { BLUIColors } from '@brightlayer-ui/colors';
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import Color from 'color';
+
+export default {
+    styleOverrides: {
+        root: {
+            width: 'calc(var(--blui-toggle-track-width, 48px) + var(--blui-toggle-container-padding, 12px) * 2)',
+            height: 'calc(var(--blui-toggle-track, 20px) + var(--blui-toggle-container-padding, 12px) * 2)',
+            padding: 'var(--blui-toggle-container-padding, 12px)',
+        },
+        switchBase: ({ theme }) => ({
+            color: theme.vars.palette.background.paper,
+            padding: 0,
+            top: '50%',
+            left: 'var(--blui-toggle-container-padding, 12px)',
+            transform: 'translateY(-50%)',
+            transition: 'none',
+            '&.Mui-checked + .MuiSwitch-track': {
+                opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+            },
+            '&.Mui-checked': {
+                transform:
+                    'translate(calc(var(--blui-toggle-track-width, 34px) - var(--blui-toggle-knob, 20px)), -50%)',
+                color: theme.vars.palette.primary.main,
+                '&.Mui-disabled': {
+                    color: theme.vars.palette.secondary.main,
+                    opacity: 'var(--blui-toggle-disabled-opacity, 0.8)',
+                },
+                '&.Mui-disabled + .MuiSwitch-track': {
+                    opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+                    backgroundColor: theme.vars.palette.secondary.main,
+                },
+            },
+            ...theme.applyStyles('dark', {
+                color: BLUIColors.black[300],
+                '&.Mui-checked + .MuiSwitch-track': {
+                    opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+                },
+                '&.Mui-checked': {
+                    color: theme.vars.palette.secondary.main,
+                    '&.Mui-disabled': {
+                        color: theme.vars.palette.primary.main,
+                    },
+                    '&.Mui-disabled + .MuiSwitch-track': {
+                        backgroundColor: theme.vars.palette.primary.main,
+                    },
+                },
+            }),
+        }),
+        colorPrimary: ({ theme }) => ({
+            ...theme.applyStyles('light', {
+                '&.Mui-disabled': {
+                    color: Color(BLUIColors.white[50]).string(),
+                },
+                '&.Mui-disabled + .MuiSwitch-track': {
+                    backgroundColor: BLUIColors.black[300],
+                },
+                '&.Mui-checked': {
+                    color: theme.vars.palette.primary.main,
+                    '&.Mui-disabled + .MuiSwitch-track': {
+                        opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+                        backgroundColor: theme.vars.palette.primary.main,
+                    },
+                },
+            }),
+        }),
+        colorSecondary: ({ theme }) => ({
+            '&.Mui-disabled': {
+                color: theme.vars.palette.background.paper,
+            },
+            '&.Mui-disabled + .MuiSwitch-track': {
+                opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+                backgroundColor: BLUIColors.black[100],
+            },
+            ...theme.applyStyles('dark', {
+                '&.Mui-disabled': {
+                    color: theme.vars.palette.Switch.defaultDisabledColor,
+                },
+                '&.Mui-disabled + .MuiSwitch-track': {
+                    backgroundColor: BLUIColors.black[300],
+                    opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+                },
+            }),
+        }),
+        track: ({ theme }) => ({
+            backgroundColor: BLUIColors.black[100],
+            opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+            height: 'var(--blui-toggle-track, 14px)',
+            width: 'var(--blui-toggle-track-width, 34px)',
+            borderRadius: 'var(--blui-toggle-track-radius, 32px)',
+            ...theme.applyStyles('dark', {
+                backgroundColor: BLUIColors.black[300],
+                opacity: 'var(--blui-toggle-track-opacity, 0.38)',
+            }),
+        }),
+        thumb: {
+            width: 'var(--blui-toggle-knob, 20px)',
+            height: 'var(--blui-toggle-knob, 20px)',
+        },
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiSwitch'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiTab.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiTab.ts
@@ -1,0 +1,90 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+
+export default {
+    styleOverrides: {
+        root: ({ theme }) => ({
+            textTransform: 'initial',
+            fontWeight: 400,
+            fontSize: 'var(--blui-tab-text)',
+            maxHeight: 'var(--blui-bar-height)',
+            padding: '16px 8px',
+            minWidth: '80px',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+
+            // Direct icon targeting for icon-only tabs
+            '& > svg': {
+                fontSize: 'var(--blui-tab-icon)',
+                width: 'var(--blui-tab-icon)',
+                height: 'var(--blui-tab-icon)',
+            },
+
+            // If you use icons in tabs, you can also add:
+            '& .MuiTab-iconWrapper': {
+                fontSize: 'var(--blui-tab-icon)',
+                width: 'var(--blui-tab-icon)',
+                height: 'var(--blui-tab-icon)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginBottom: 0,
+                // Target direct SVG icons
+                '& > svg': {
+                    fontSize: 'var(--blui-tab-icon)',
+                    width: 'var(--blui-tab-icon)',
+                    height: 'var(--blui-tab-icon)',
+                },
+                // Target icons wrapped in Badge
+                '& .MuiBadge-root': {
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    '& svg': {
+                        fontSize: 'var(--blui-tab-icon)',
+                        width: 'var(--blui-tab-icon)',
+                        height: 'var(--blui-tab-icon)',
+                    },
+                },
+            },
+            '&.Mui-selected': {
+                fontWeight: 600,
+            },
+            ...theme.applyStyles('dark', {
+                fontWeight: 400,
+                '&.Mui-selected': {
+                    fontWeight: 600,
+                },
+            }),
+        }),
+        textColorPrimary: ({ theme }) => ({
+            ...theme.applyStyles('light', {
+                color: theme.vars.palette.text.primary,
+                opacity: 0.7,
+                '&.Mui-selected': {
+                    color: theme.vars.palette.primary.main,
+                    opacity: 1,
+                },
+            }),
+        }),
+        textColorSecondary: ({ theme }) => ({
+            ...theme.applyStyles('light', {
+                color: theme.vars.palette.text.secondary,
+                opacity: 0.7,
+                '&.Mui-selected': {
+                    color: theme.vars.palette.secondary.main,
+                    opacity: 1,
+                },
+            }),
+        }),
+        textColorInherit: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                color: theme.vars.palette.text.secondary,
+                opacity: 1,
+                '&.Mui-selected': {
+                    color: theme.vars.palette.primary.main,
+                },
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiTab'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiTabs.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiTabs.ts
@@ -1,0 +1,17 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+
+export default {
+    styleOverrides: {
+        root: ({ theme }) => ({
+            ...theme.applyStyles('dark', {
+                color: theme.vars.palette.text.secondary,
+            }),
+        }),
+        indicator: ({ theme }) => ({
+            backgroundColor: theme.vars.palette.primary.main,
+            ...theme.applyStyles('dark', {
+                backgroundColor: theme.vars.palette.primary.main,
+            }),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiTabs'];

--- a/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiToggleButton.ts
+++ b/packages/themes/src/hmiTheme/hmiComponentStylesOverrides/MuiToggleButton.ts
@@ -1,0 +1,16 @@
+import { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import baseOverride from '../../componentStylesOverrides/MuiToggleButton';
+
+const baseRoot = baseOverride!.styleOverrides!.root as (args: any) => object;
+
+export default {
+    ...baseOverride,
+    styleOverrides: {
+        ...baseOverride!.styleOverrides,
+        root: (args: Parameters<typeof baseRoot>[0]) => ({
+            height: 'var(--blui-segmented-button-height, 56px)',
+            padding: '0 var(--blui-segmented-button-padding, 24px)',
+            ...baseRoot(args),
+        }),
+    },
+} as Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme>['MuiToggleButton'];

--- a/packages/themes/src/hmiTheme/hmiComponents.ts
+++ b/packages/themes/src/hmiTheme/hmiComponents.ts
@@ -1,0 +1,161 @@
+import type {} from '@mui/material/themeCssVarsAugmentation';
+import type { Components, Theme, CssVarsTheme } from '@mui/material/styles';
+import MuiAvatar from './hmiComponentStylesOverrides/MuiAvatar';
+import MuiAppBar from './hmiComponentStylesOverrides/MuiAppBar';
+import MuiBottomNavigation from './hmiComponentStylesOverrides/MuiBottomNavigation';
+import MuiButton from './hmiComponentStylesOverrides/MuiButton';
+import MuiChip from './hmiComponentStylesOverrides/MuiChip';
+import MuiDrawer from './hmiComponentStylesOverrides/MuiDrawer';
+import MuiLinearProgress from './hmiComponentStylesOverrides/MuiLinearProgress';
+import MuiCircularProgress from './hmiComponentStylesOverrides/MuiCircularProgress';
+import MuiSwitch from './hmiComponentStylesOverrides/MuiSwitch';
+import MuiTab from './hmiComponentStylesOverrides/MuiTab';
+import MuiTabs from './hmiComponentStylesOverrides/MuiTabs';
+import MuiInputBase from './hmiComponentStylesOverrides/MuiInputBase';
+import MuiFilledInput from './hmiComponentStylesOverrides/MuiFilledInput';
+import MuiFormLabel from './hmiComponentStylesOverrides/MuiFormLabel';
+import MuiFormHelperText from './hmiComponentStylesOverrides/MuiFormHelperText';
+import MuiToggleButton from './hmiComponentStylesOverrides/MuiToggleButton';
+import MuiRadio from './hmiComponentStylesOverrides/MuiRadio';
+import MuiCard from './hmiComponentStylesOverrides/MuiCard';
+import MuiInputLabel from './hmiComponentStylesOverrides/MuiInputLabel';
+import MuiStepper from './hmiComponentStylesOverrides/MuiStepper';
+// shared overrides (identical between themes)
+import MuiBottomNavigationAction from '../componentStylesOverrides/MuiBottomNavigationAction';
+import MuiBadge from '../componentStylesOverrides/MuiBadge';
+import MuiBackdrop from '../componentStylesOverrides/MuiBackdrop';
+import MuiButtonGroup from '../componentStylesOverrides/MuiButtonGroup';
+import MuiCheckbox from '../componentStylesOverrides/MuiCheckbox';
+import MuiButtonBase from '../componentStylesOverrides/MuiButtonBase';
+import MuiFab from '../componentStylesOverrides/MuiFab';
+import MuiListItem from '../componentStylesOverrides/MuiListItem';
+import MuiListSubheader from '../componentStylesOverrides/MuiListSubheader';
+import MuiMobileStepper from '../componentStylesOverrides/MuiMobileStepper';
+import MuiSlider from '../componentStylesOverrides/MuiSlider';
+import MuiSnackbarContent from '../componentStylesOverrides/MuiSnackbarContent';
+import MuiStepConnector from '../componentStylesOverrides/MuiStepConnector';
+import MuiStep from '../componentStylesOverrides/MuiStep';
+import MuiStepIcon from '../componentStylesOverrides/MuiStepIcon';
+import MuiStepLabel from '../componentStylesOverrides/MuiStepLabel';
+import MuiTableCell from '../componentStylesOverrides/MuiTableCell';
+import MuiTableHead from '../componentStylesOverrides/MuiTableHead';
+import MuiTableRow from '../componentStylesOverrides/MuiTableRow';
+import MuiTableSortLabel from '../componentStylesOverrides/MuiTableSortLabel';
+import MuiTooltip from '../componentStylesOverrides/MuiTooltip';
+import MuiInput from '../componentStylesOverrides/MuiInput';
+import MuiOutlinedInput from '../componentStylesOverrides/MuiOutlinedInput';
+import MuiToggleButtonGroup from '../componentStylesOverrides/MuiToggleButtonGroup';
+
+declare module '@mui/material/styles' {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface Palette {
+        statusBar: {
+            default: string;
+            alarm: string;
+            warning: string;
+            success: string;
+            primary: string;
+        };
+        scrollbar: {
+            button: string;
+        };
+        gauge: {
+            progress: string;
+            track: string;
+            label: string;
+        };
+        bucketGauge: {
+            alarm: string;
+            warning: string;
+            test: string;
+            healthy: string;
+        };
+        warningAlternate: Palette['primary'];
+        statusCountItem: {
+            warning: string;
+            warningText: string;
+            errorText: string;
+            info: string;
+            infoText: string;
+        };
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+    interface PaletteOptions {
+        statusBar?: {
+            default: string;
+            alarm: string;
+            warning: string;
+            success: string;
+            primary: string;
+        };
+        scrollbar?: {
+            button: string;
+        };
+        gauge?: {
+            progress: string;
+            track: string;
+            label: string;
+        };
+        bucketGauge?: {
+            alarm: string;
+            warning: string;
+            test: string;
+            healthy: string;
+        };
+        warningAlternate?: PaletteOptions['primary'];
+        statusCountItem?: {
+            warning: string;
+            warningText: string;
+            errorText: string;
+            info: string;
+            infoText: string;
+        };
+    }
+}
+
+export const hmiComponentOverrides: Components<Omit<Theme, 'components' | 'palette'> & CssVarsTheme> = {
+    MuiAvatar: MuiAvatar,
+    MuiAppBar: MuiAppBar,
+    MuiBottomNavigation: MuiBottomNavigation,
+    MuiBottomNavigationAction: MuiBottomNavigationAction,
+    MuiBadge: MuiBadge,
+    MuiBackdrop: MuiBackdrop,
+    MuiButton: MuiButton,
+    MuiButtonGroup: MuiButtonGroup,
+    MuiCheckbox: MuiCheckbox,
+    MuiButtonBase: MuiButtonBase,
+    MuiChip: MuiChip,
+    MuiDrawer: MuiDrawer,
+    MuiFab: MuiFab,
+    MuiListItem: MuiListItem,
+    MuiListSubheader: MuiListSubheader,
+    MuiMobileStepper: MuiMobileStepper,
+    MuiLinearProgress: MuiLinearProgress,
+    MuiCircularProgress: MuiCircularProgress,
+    MuiSlider: MuiSlider,
+    MuiSnackbarContent: MuiSnackbarContent,
+    MuiStepConnector: MuiStepConnector,
+    MuiStep: MuiStep,
+    MuiStepIcon: MuiStepIcon,
+    MuiStepLabel: MuiStepLabel,
+    MuiSwitch: MuiSwitch,
+    MuiTableCell: MuiTableCell,
+    MuiTableHead: MuiTableHead,
+    MuiTableRow: MuiTableRow,
+    MuiTableSortLabel: MuiTableSortLabel,
+    MuiTab: MuiTab,
+    MuiTabs: MuiTabs,
+    MuiTooltip: MuiTooltip,
+    MuiInputBase: MuiInputBase,
+    MuiInput: MuiInput,
+    MuiInputLabel: MuiInputLabel,
+    MuiFilledInput: MuiFilledInput,
+    MuiOutlinedInput: MuiOutlinedInput,
+    MuiFormLabel: MuiFormLabel,
+    MuiFormHelperText: MuiFormHelperText,
+    MuiToggleButtonGroup: MuiToggleButtonGroup,
+    MuiToggleButton: MuiToggleButton,
+    MuiRadio: MuiRadio,
+    MuiCard: MuiCard,
+    MuiStepper: MuiStepper,
+};

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -9,4 +9,5 @@ import type {} from '@mui/material/themeCssVarsAugmentation';
 import { blueThemes } from './blueMergedTheme';
 export { blueThemes as theme } from './blueMergedTheme';
 export { blueThemes as blueThemes } from './blueMergedTheme';
+export { default as HMIThemeProvider } from './HMIThemeProvider';
 export default blueThemes;

--- a/packages/themes/tsconfig.json
+++ b/packages/themes/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "jsx": "react",
         "target": "ESNext",
         "module": "ESNext",
         "declaration": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -972,7 +972,7 @@ importers:
         version: 27.5.1
       jest-watch-typeahead:
         specifier: ^1.0.0
-        version: 1.1.0(jest@27.5.1)
+        version: 1.1.0(jest@27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)))
       mini-css-extract-plugin:
         specifier: ^2.4.5
         version: 2.10.2(webpack@5.106.2(postcss@8.5.15))
@@ -1153,7 +1153,7 @@ importers:
         version: 7.15.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-scripts:
         specifier: ^5.0.0
-        version: 5.0.1(eslint@8.57.1)(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(yaml@2.9.0)
+        version: 5.0.1(eslint@8.57.1)(react@19.2.6)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))(type-fest@4.41.0)(typescript@5.9.3)(yaml@2.9.0)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -1214,7 +1214,7 @@ importers:
         version: 0.4.26(eslint@8.57.1)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       prettier:
         specifier: ^3.2.4
         version: 3.8.3
@@ -1958,7 +1958,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)))(typescript@5.9.3)
       tsc-esm-fix:
         specifier: ^3.1.2
         version: 3.1.2
@@ -2115,7 +2115,7 @@ importers:
         version: 0.13.11
       ts-jest:
         specifier: ^29.4.9
-        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+        version: 29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)))(typescript@5.9.3)
       tsc-esm-fix:
         specifier: ^3.1.2
         version: 3.1.2
@@ -2144,10 +2144,13 @@ importers:
     devDependencies:
       '@mui/material':
         specifier: ^7.1.1
-        version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 7.3.11(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/color':
         specifier: ^4.2.0
         version: 4.2.1
+      '@types/react':
+        specifier: ^19.2.15
+        version: 19.2.15
       npm-license-crawler:
         specifier: ^0.2.1
         version: 0.2.1
@@ -6104,6 +6107,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
   '@types/resolve@1.17.1':
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -16172,6 +16178,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.6)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@emotion/serialize@1.3.3':
     dependencies:
       '@emotion/hash': 0.9.2
@@ -16196,6 +16219,22 @@ snapshots:
       '@types/react': 19.2.14
     transitivePeerDependencies:
       - supports-color
+
+  '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/is-prop-valid': 1.4.0
+      '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.6)
+      '@emotion/utils': 1.4.2
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@emotion/unitless@0.10.0': {}
 
@@ -17118,6 +17157,43 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  '@jest/core@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 27.5.1
+      '@jest/reporters': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
+      '@types/node': 24.3.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 27.5.1
+      jest-config: 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
+      jest-haste-map: 27.5.1
+      jest-message-util: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-resolve-dependencies: 27.5.1
+      jest-runner: 27.5.1
+      jest-runtime: 27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      jest-watcher: 27.5.1
+      micromatch: 4.0.8
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+
   '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -17133,6 +17209,41 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
       jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.3.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -18045,6 +18156,27 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/react': 19.2.14
 
+  '@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/core-downloads-tracker': 7.3.11
+      '@mui/system': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
+      '@mui/types': 7.4.12(@types/react@19.2.15)
+      '@mui/utils': 7.3.11(@types/react@19.2.15)(react@19.2.6)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.15)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-is: 19.2.6
+      react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
+      '@types/react': 19.2.15
+
   '@mui/private-theming@5.17.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -18071,6 +18203,15 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@mui/private-theming@7.3.11(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/utils': 7.3.11(@types/react@19.2.15)(react@19.2.6)
+      prop-types: 15.8.1
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   '@mui/styled-engine-sc@7.3.10(@types/react@19.2.14)(styled-components@6.4.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))':
     dependencies:
@@ -18120,6 +18261,19 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.6)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
+
+  '@mui/styled-engine@7.3.10(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/sheet': 1.4.0
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.6
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
 
   '@mui/styles@6.4.8(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -18192,6 +18346,22 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6)
       '@types/react': 19.2.14
 
+  '@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/private-theming': 7.3.11(@types/react@19.2.15)(react@19.2.6)
+      '@mui/styled-engine': 7.3.10(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+      '@mui/types': 7.4.12(@types/react@19.2.15)
+      '@mui/utils': 7.3.11(@types/react@19.2.15)(react@19.2.6)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.6
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
+      '@types/react': 19.2.15
+
   '@mui/types@7.2.24(@types/react@19.2.14)':
     optionalDependencies:
       '@types/react': 19.2.14
@@ -18201,6 +18371,12 @@ snapshots:
       '@babel/runtime': 7.29.2
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@mui/types@7.4.12(@types/react@19.2.15)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   '@mui/utils@5.17.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -18237,6 +18413,18 @@ snapshots:
       react-is: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@mui/utils@7.3.11(@types/react@19.2.15)(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@mui/types': 7.4.12(@types/react@19.2.15)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-is: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   '@mui/x-date-pickers@7.29.4(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mui/system@7.3.11(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(react@19.2.6))(@types/react@19.2.14)(date-fns@2.30.0)(moment@2.30.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -19237,6 +19425,10 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
+  '@types/react-transition-group@4.4.12(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
   '@types/react@16.14.69':
     dependencies:
       '@types/prop-types': 15.7.13
@@ -19250,6 +19442,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/react@19.2.15':
     dependencies:
       csstype: 3.2.3
 
@@ -21364,13 +21560,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0):
+  create-jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -22249,7 +22445,7 @@ snapshots:
       eslint: 8.57.1
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@27.5.1)(typescript@5.9.3)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)))(typescript@5.9.3)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -22281,6 +22477,33 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@9.33.0(jiti@1.21.7))
       eslint-plugin-react-hooks: 4.6.2(eslint@9.33.0(jiti@1.21.7))
       eslint-plugin-testing-library: 5.11.1(eslint@9.33.0(jiti@1.21.7))(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+
+  eslint-config-react-app@7.0.1(eslint@8.57.1)(jest@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@8.57.1)
+      '@rushstack/eslint-patch': 1.16.1
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      babel-preset-react-app: 10.1.0
+      confusing-browser-globals: 1.0.11
+      eslint: 8.57.1
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)))(typescript@5.9.3)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
+      eslint-plugin-react: 7.37.5(eslint@8.57.1)
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
+      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -22400,13 +22623,24 @@ snapshots:
       eslint: 8.57.1
       requireindex: 1.2.0
 
-  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@27.5.1)(typescript@5.9.3):
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
       jest: 27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(jest@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint: 8.57.1
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      jest: 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -24400,6 +24634,27 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  jest-cli@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      import-local: 3.2.0
+      jest-config: 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      prompts: 2.4.2
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+
   jest-cli@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
@@ -24419,16 +24674,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0):
+  jest-cli@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
+      create-jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -24485,6 +24740,40 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       ts-node: 10.9.2(@types/node@22.13.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
+  jest-config@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 27.5.1
+      '@jest/types': 27.5.1
+      babel-jest: 27.5.1(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-node: 27.5.1
+      jest-get-type: 27.5.1
+      jest-jasmine2: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-runner: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 27.5.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      ts-node: 10.9.2(@types/node@24.3.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -24549,6 +24838,37 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.3.0
       ts-node: 10.9.2(@types/node@22.13.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.3.0
+      ts-node: 10.9.2(@types/node@24.3.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -25274,11 +25594,22 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.4.1
 
-  jest-watch-typeahead@1.1.0(jest@27.5.1):
+  jest-watch-typeahead@1.1.0(jest@27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))):
     dependencies:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest: 27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+      jest-regex-util: 28.0.2
+      jest-watcher: 28.1.3
+      slash: 4.0.0
+      string-length: 5.0.1
+      strip-ansi: 7.2.0
+
+  jest-watch-typeahead@1.1.0(jest@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))):
+    dependencies:
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      jest: 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       jest-regex-util: 28.0.2
       jest-watcher: 28.1.3
       slash: 4.0.0
@@ -25373,6 +25704,18 @@ snapshots:
       - ts-node
       - utf-8-validate
 
+  jest@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
+      import-local: 3.2.0
+      jest-cli: 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
+
   jest@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
@@ -25385,12 +25728,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0):
+  jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
+      jest-cli: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -27998,7 +28341,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
 
-  react-scripts@5.0.1(eslint@8.57.1)(react@19.2.6)(type-fest@4.41.0)(typescript@5.9.3)(yaml@2.9.0):
+  react-scripts@5.0.1(eslint@8.57.1)(react@19.2.6)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))(type-fest@4.41.0)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       '@babel/core': 7.29.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@5.2.1(webpack@5.106.2(postcss@8.5.15)))(webpack@5.106.2(postcss@8.5.15))
@@ -28016,15 +28359,15 @@ snapshots:
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       eslint: 8.57.1
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0))(@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0))(eslint@8.57.1)(jest@27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)))(typescript@5.9.3)
+      eslint-config-react-app: 7.0.1(eslint@8.57.1)(jest@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)))(typescript@5.9.3)
       eslint-webpack-plugin: 3.2.0(eslint@8.57.1)(webpack@5.106.2(postcss@8.5.15))
       file-loader: 6.2.0(webpack@5.106.2(postcss@8.5.15))
       fs-extra: 10.1.0
       html-webpack-plugin: 5.6.7(webpack@5.106.2(postcss@8.5.15))
       identity-obj-proxy: 3.0.0
-      jest: 27.5.1(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3))
+      jest: 27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3))
       jest-resolve: 27.5.1
-      jest-watch-typeahead: 1.1.0(jest@27.5.1)
+      jest-watch-typeahead: 1.1.0(jest@27.5.1(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.3)))
       mini-css-extract-plugin: 2.10.2(webpack@5.106.2(postcss@8.5.15))
       postcss: 8.5.15
       postcss-flexbugs-fixes: 5.0.2(postcss@8.5.15)
@@ -29547,7 +29890,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+  ts-jest@29.4.10(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@30.4.1)(jest@29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-[integrated hmi theme sizing to react theme](https://eaton-corp.atlassian.net/browse/BLUI-7255)
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)


<img width="1489" height="917" alt="Screenshot 2026-05-26 at 9 59 00 AM" src="https://github.com/user-attachments/assets/d1cc5a2f-f07d-4d4e-b3ef-b8ace7a3fe5a" />

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- go to index.tsx in apps/showcase/src
- uncomment the hmi theme code and comment out BLUI Theme code
- run yarn start:showcase at the monorepo level
- verify the sizing of components compatible with HMI based on [figma](https://www.figma.com/design/tWRxhJ27Qr8r1xyUYQjZCr/HMI-Design-System?node-id=1002-2&p=f&m=dev)

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [x] Code passes all linting checks
- [x] All tests pass
- [ ] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] Changelog has been updated (if applicable)
