### PR TITLE
updated docs for data table

### DIFF
--- a/docs/src/componentDocs/DataTable/examples/ExternalToolbarDataTable.tsx
+++ b/docs/src/componentDocs/DataTable/examples/ExternalToolbarDataTable.tsx
@@ -41,7 +41,7 @@ const handleSave = useCallback(async () => {
                 </Button>
             </span>
         </Tooltip>
-        <Tooltip title="Ctrl+Shift+Z">
+        <Tooltip title="Ctrl+Shift+Z / Ctrl+Y">
             <span>
                 <Button variant="outlined" size="small" startIcon={<RedoIcon />}
                     onClick={tableState?.redo} disabled={!tableState?.canRedo}>

--- a/docs/src/componentDocs/DataTable/examples/ExternalToolbarDataTableExample.tsx
+++ b/docs/src/componentDocs/DataTable/examples/ExternalToolbarDataTableExample.tsx
@@ -85,7 +85,7 @@ export const ExternalToolbarDataTableExample = (): React.JSX.Element => {
                             </Button>
                         </span>
                     </Tooltip>
-                    <Tooltip title="Ctrl+Shift+Z">
+                    <Tooltip title="Ctrl+Shift+Z / Ctrl+Y">
                         <span>
                             <Button
                                 variant="outlined"

--- a/docs/src/componentDocs/DataTable/examples/ReadOnlyDataTable.tsx
+++ b/docs/src/componentDocs/DataTable/examples/ReadOnlyDataTable.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
+import { ReadOnlyDataTableExample } from './ReadOnlyDataTableExample';
+
+const codeSnippet = `<DataTable
+    columns={columns}
+    data={data}
+    editable={false}
+    enableCreate={false}
+    enableDelete={false}
+    enableDuplicate={false}
+    enableRowActions={false}
+/>`;
+
+export const ReadOnlyDataTable = (): React.JSX.Element => (
+    <Box>
+        <ReadOnlyDataTableExample />
+        <CodeBlock code={codeSnippet} language="jsx" dataLine={'4'} />
+        <CodeBlockActionButtonRow
+            copyText={codeSnippet}
+            url="componentDocs/DataTable/examples/ReadOnlyDataTableExample.tsx"
+        />
+    </Box>
+);

--- a/docs/src/componentDocs/DataTable/examples/ReadOnlyDataTableExample.tsx
+++ b/docs/src/componentDocs/DataTable/examples/ReadOnlyDataTableExample.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { DataTable, type DataTableColumnDef } from '@brightlayer-ui/react-components';
+import { ExampleShowcase } from '../../../shared';
+
+type Device = {
+    id: string;
+    name: string;
+    status: 'Online' | 'Offline' | 'Maintenance';
+    site: string;
+    uptimeDays: number;
+};
+
+const initialData: Device[] = [
+    { id: '1', name: 'Edge Gateway 01', status: 'Online', site: 'Phoenix', uptimeDays: 187 },
+    { id: '2', name: 'Panel Controller 12', status: 'Maintenance', site: 'Austin', uptimeDays: 12 },
+    { id: '3', name: 'Power Monitor 08', status: 'Offline', site: 'Chicago', uptimeDays: 0 },
+];
+
+const columns: Array<DataTableColumnDef<Device>> = [
+    { accessorKey: 'name', header: 'Device Name', cellType: 'text' },
+    { accessorKey: 'status', header: 'Status', cellType: 'text' },
+    { accessorKey: 'site', header: 'Site', cellType: 'text' },
+    { accessorKey: 'uptimeDays', header: 'Uptime (Days)', cellType: 'number', size: 130 },
+];
+
+export const ReadOnlyDataTableExample = (): React.JSX.Element => (
+    <ExampleShowcase sx={{ p: 2 }}>
+        <DataTable
+            columns={columns}
+            data={initialData}
+            editable={false}
+            enableCreate={false}
+            enableDelete={false}
+            enableDuplicate={false}
+            enableRowActions={false}
+            createButtonText="Add Device"
+        />
+    </ExampleShowcase>
+);

--- a/docs/src/componentDocs/DataTable/examples/index.tsx
+++ b/docs/src/componentDocs/DataTable/examples/index.tsx
@@ -1,4 +1,5 @@
 export * from './BasicDataTable';
+export * from './ReadOnlyDataTable';
 export * from './RowEditingDataTable';
 export * from './CustomCellsDataTable';
 export * from './ExternalToolbarDataTable';

--- a/docs/src/componentDocs/DataTable/markdown/DataTableAPIDocs.mdx
+++ b/docs/src/componentDocs/DataTable/markdown/DataTableAPIDocs.mdx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 
-# Editable Table
+# Data Table
 
 The `<DataTable>` component is a fully-featured data table built on top of [material-react-table](https://www.material-react-table.com/) that provides CRUD (Create, Read, Update, Delete) operations with inline validation, undo/redo history, and an external state API for driving custom toolbars.
 
@@ -8,43 +8,44 @@ The `<DataTable>` component is a fully-featured data table built on top of [mate
 
 <Box>
 
-| Prop Name             | Description                                                                                                    | Type                                                              | Required | Default           |
-| :-------------------- | :------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------- | :------- | :---------------- |
-| columns               | Column definitions for the table. Use `DataTableColumnDef<TData>` to access the `cellStyle` convenience prop | `Array<DataTableColumnDef<TData>>`                            | yes      |                   |
-| data                  | Initial row data for the table                                                                                 | `TData[]`                                                         | no       | `[]`              |
-| enableCreate          | Whether to show the "add row" control                                                                          | `boolean`                                                         | no       | `true`            |
-| editable              | Whether to allow editing rows                                                                                  | `boolean`                                                         | no       | `true`            |
-| enableDelete          | Whether to allow deleting rows                                                                                 | `boolean`                                                         | no       | `true`            |
-| enableDuplicate       | Whether to allow duplicating rows                                                                              | `boolean`                                                         | no       | `false`           |
-| createDisplayMode     | How new rows are created — `'row'` (inline) or `'modal'`                                                       | `'row'` \| `'modal'`                                              | no       | `'row'`           |
-| editDisplayMode       | How rows are edited — `'cell'`, `'row'`, `'table'`, or `'modal'`                                               | `'cell'` \| `'row'` \| `'table'` \| `'modal'`                    | no       | `'cell'`          |
-| onValidate            | Called on cell save and when evaluating save eligibility; return an error map keyed by field name              | `(row: TData) => Partial<Record<keyof TData, string \| undefined>>` | no       |                   |
-| onCreate              | Called when a new row is saved. The temporary internal ID is removed before this callback is invoked          | `(row: TData) => Promise<void> \| void`                           | no       |                   |
-| onUpdate              | Called for each edited row when changes are committed                                                          | `(row: TData) => Promise<void> \| void`                           | no       |                   |
-| onDelete              | Called when a persisted row is deleted; receives the row's ID. Unsaved new/duplicate rows are removed locally | `(id: string \| number) => Promise<void> \| void`                 | no       |                   |
-| onDuplicate           | Called when a duplicated row is saved. The temporary internal ID is removed before this callback is invoked   | `(row: TData) => Promise<void> \| void`                           | no       |                   |
-| getRowId              | Returns the unique ID for a row                                                                                | `(row: TData) => string`                                          | no       | `(row) => row.id` |
-| isLoading             | Show a loading overlay                                                                                         | `boolean`                                                         | no       | `false`           |
-| isSaving              | Show a saving overlay                                                                                          | `boolean`                                                         | no       | `false`           |
-| error                 | Error message displayed in the toolbar alert banner                                                            | `string`                                                          | no       |                   |
-| enableColumnPinning   | Allow columns to be pinned                                                                                     | `boolean`                                                         | no       | `true`            |
-| enableRowActions      | Show the row actions column (edit / delete / duplicate buttons)                                                | `boolean`                                                         | no       | `true`            |
-| enableCellActions     | Enable right-click context menu on cells                                                                       | `boolean`                                                         | no       | `false`           |
-| enableClickToCopy     | Enable click-to-copy on cells (`true` or `'context-menu'`)                                                     | `boolean` \| `'context-menu'`                                     | no       | `false`           |
-| enableSorting         | Enable column sorting                                                                                          | `boolean`                                                         | no       | `false`           |
-| enableColumnFilters   | Enable column filter controls in the top toolbar                                                               | `boolean`                                                         | no       | `false`           |
-| enableColumnActions   | Enable the column actions menu (hide/show columns, etc.)                                                       | `boolean`                                                         | no       | `false`           |
-| tableOptions          | Escape hatch — any additional `MRT_TableOptions` props passed directly to material-react-table                 | `Partial<MRT_TableOptions<TData>>`                                 | no       |                   |
-| createButtonText      | Label for the bottom-toolbar create button                                                                     | `string`                                                          | no       | `'New data point'`|
-| deleteConfirmMessage  | Confirmation message (or factory function) shown before a row is deleted                                       | `string \| ((row: TData) => string)`                               | no       | `'Are you sure you want to delete this item?'` |
-| minHeight             | Minimum height of the table container                                                                          | `string \| number`                                                 | no       | `'109px'`         |
-| enableUndoRedo        | Enable undo/redo history with Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z (or Ctrl/Cmd+Y). Tracks cell edits/add/delete/duplicate and clears on save/reset | `boolean`                                                         | no       | `false`           |
-| onStateChange         | Called whenever state changes; receives a `DataTableState` snapshot for driving external controls          | `(state: DataTableState) => void`                              | no       |                   |
+| Prop Name            | Description                                                                                                                                    | Type                                                                | Required | Default                                        |
+| :------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------ | :------- | :--------------------------------------------- |
+| columns              | Column definitions for the table. Use `DataTableColumnDef<TData>` to access the `cellStyle` convenience prop                                   | `Array<DataTableColumnDef<TData>>`                                  | yes      |                                                |
+| data                 | Initial row data for the table                                                                                                                 | `TData[]`                                                           | no       | `[]`                                           |
+| enableCreate         | Whether to show the "add row" control                                                                                                          | `boolean`                                                           | no       | `true`                                         |
+| editable             | Whether to allow editing rows                                                                                                                  | `boolean`                                                           | no       | `true`                                         |
+| enableDelete         | Whether to allow deleting rows                                                                                                                 | `boolean`                                                           | no       | `true`                                         |
+| enableDuplicate      | Whether to allow duplicating rows                                                                                                              | `boolean`                                                           | no       | `false`                                        |
+| createDisplayMode    | How new rows are created — `'row'` (inline) or `'modal'`                                                                                       | `'row'` \| `'modal'`                                                | no       | `'row'`                                        |
+| editDisplayMode      | How rows are edited — `'cell'`, `'row'`, `'table'`, or `'modal'`                                                                               | `'cell'` \| `'row'` \| `'table'` \| `'modal'`                       | no       | `'cell'`                                       |
+| onValidate           | Called on cell save and when evaluating save eligibility; return an error map keyed by field name                                              | `(row: TData) => Partial<Record<keyof TData, string \| undefined>>` | no       |                                                |
+| onCreate             | Called when a new row is saved. The temporary internal ID is removed before this callback is invoked                                           | `(row: TData) => Promise<void> \| void`                             | no       |                                                |
+| onUpdate             | Called for each edited row when changes are committed                                                                                          | `(row: TData) => Promise<void> \| void`                             | no       |                                                |
+| onDelete             | Called when a persisted row is deleted; receives the row's ID. Unsaved new/duplicate rows are removed locally                                  | `(id: string \| number) => Promise<void> \| void`                   | no       |                                                |
+| onDuplicate          | Called when a duplicated row is saved. The temporary internal ID is removed before this callback is invoked                                    | `(row: TData) => Promise<void> \| void`                             | no       |                                                |
+| getRowId             | Returns the unique ID for a row                                                                                                                | `(row: TData) => string`                                            | no       | `(row) => row.id`                              |
+| isLoading            | Show a loading overlay                                                                                                                         | `boolean`                                                           | no       | `false`                                        |
+| isSaving             | Show a saving overlay                                                                                                                          | `boolean`                                                           | no       | `false`                                        |
+| error                | Error message displayed in the toolbar alert banner                                                                                            | `string`                                                            | no       |                                                |
+| enableColumnPinning  | Allow columns to be pinned                                                                                                                     | `boolean`                                                           | no       | `true`                                         |
+| enableRowActions     | Show the row actions column (edit / delete / duplicate buttons)                                                                                | `boolean`                                                           | no       | `true`                                         |
+| enableCellActions    | Enable right-click context menu on cells                                                                                                       | `boolean`                                                           | no       | `false`                                        |
+| enableClickToCopy    | Enable click-to-copy on cells (`true` or `'context-menu'`)                                                                                     | `boolean` \| `'context-menu'`                                       | no       | `false`                                        |
+| enableSorting        | Enable column sorting                                                                                                                          | `boolean`                                                           | no       | `false`                                        |
+| enableColumnFilters  | Enable column filter controls in the top toolbar                                                                                               | `boolean`                                                           | no       | `false`                                        |
+| enableColumnActions  | Enable the column actions menu (hide/show columns, etc.)                                                                                       | `boolean`                                                           | no       | `false`                                        |
+| tableOptions         | Escape hatch — any additional `MRT_TableOptions` props passed directly to material-react-table                                                 | `Partial<MRT_TableOptions<TData>>`                                  | no       |                                                |
+| createButtonText     | Label for the bottom-toolbar create button                                                                                                     | `string`                                                            | no       | `'New data point'`                             |
+| deleteConfirmMessage | Confirmation message (or factory function) shown before a row is deleted                                                                       | `string \| ((row: TData) => string)`                                | no       | `'Are you sure you want to delete this item?'` |
+| minHeight            | Minimum height of the table container                                                                                                          | `string \| number`                                                  | no       | `'109px'`                                      |
+| enableUndoRedo       | Enable undo/redo history with Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z (or Ctrl/Cmd+Y). Tracks cell edits/add/delete/duplicate and clears on save/reset | `boolean`                                                           | no       | `false`                                        |
+| onStateChange        | Called whenever state changes; receives a `DataTableState` snapshot for driving external controls                                              | `(state: DataTableState) => void`                                   | no       |                                                |
 
 </Box>
 
 ### Behavior Notes
 
+- Setting `editable={false}` puts the table in read-only mode: cell/row editing is disabled and create/delete/duplicate operations are not available.
 - Delete confirmation (`deleteConfirmMessage`) is only shown for persisted rows. Unsaved rows created in-session are removed immediately.
 - New and duplicated rows are tracked with internal temporary IDs until save. When `onCreate` / `onDuplicate` is called, that temporary `id` is stripped out.
 - Undo/redo history is capped internally and reset after an explicit save or reset, making the current committed state the new baseline.
@@ -58,18 +59,19 @@ The `<DataTable>` component is a fully-featured data table built on top of [mate
 
 <Box>
 
-| Prop Name    | Description                                                                                                                      | Type                                                  | Required | Default  |
-| :----------- | :------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------- | :------- | :------- |
-| cellType     | Type of cell editor to render: `'text'`, `'number'`, `'select'`, or `'binary'` (checkbox)                                       | `'text'` \| `'number'` \| `'select'` \| `'binary'`    | no       | `'text'` |
-| headerAlign  | Horizontal alignment of the column header text                                                                                   | `'left'` \| `'center'` \| `'right'`                   | no       | `'left'` |
-| required     | When `true`, appends a red `*` to the column header to indicate the field is required when editing                               | `boolean`                                             | no       | `false`  |
-| cellStyle    | Return MUI `sx` styles applied per-cell based on the cell value or row data. Merged on top of `muiTableBodyCellProps.sx`.        | `(params: CellStyleParams<TData>) => SxProps<Theme>`  | no       |          |
+| Prop Name   | Description                                                                                                               | Type                                                 | Required | Default  |
+| :---------- | :------------------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------- | :------- | :------- |
+| cellType    | Type of cell editor to render: `'text'`, `'number'`, `'select'`, or `'binary'` (checkbox)                                 | `'text'` \| `'number'` \| `'select'` \| `'binary'`   | no       | `'text'` |
+| headerAlign | Horizontal alignment of the column header text                                                                            | `'left'` \| `'center'` \| `'right'`                  | no       | `'left'` |
+| required    | When `true`, appends a red `*` to the column header to indicate the field is required when editing                        | `boolean`                                            | no       | `false`  |
+| cellStyle   | Return MUI `sx` styles applied per-cell based on the cell value or row data. Merged on top of `muiTableBodyCellProps.sx`. | `(params: CellStyleParams<TData>) => SxProps<Theme>` | no       |          |
 
 </Box>
 
 > For column-wide static styling use `muiTableBodyCellProps: { sx: { ... } }`. Use `cellStyle` for dynamic per-row / per-value styling.
 
 **Built-in column behaviours added by `DataTable`:**
+
 - **Numeric alignment** — columns whose first row value is a `number` are automatically right-aligned in both the read and edit state.
 - **Unsaved-change indicator** — a blue dot appears at the top-right corner of any cell that has a pending (unsaved) edit.
 - **Validation error display** — cells with a validation error receive a red outline; hovering shows the error message in a tooltip.
@@ -85,18 +87,17 @@ When `save` or `reset` is invoked, `DataTable` first closes any actively edited 
 
 <Box>
 
-| Field              | Description                                                                 | Type                |
-| :----------------- | :-------------------------------------------------------------------------- | :------------------ |
-| canUndo            | Whether there is at least one action that can be undone                     | `boolean`           |
-| canRedo            | Whether there is at least one action that can be redone                     | `boolean`           |
-| hasPendingChanges  | Whether there are unsaved cell edits, row additions, or deletions           | `boolean`           |
-| hasValidationErrors| Whether any cell currently has a validation error                           | `boolean`           |
-| canSave            | Whether saving is currently permitted — there are pending changes and every pending row passes `onValidate` | `boolean` |
-| undo               | Undo the last recorded action                                               | `() => void`        |
-| redo               | Redo the last undone action                                                 | `() => void`        |
-| save               | Commit all pending changes (calls `onUpdate` for each edited row) after closing any active edit cell | `() => Promise<void>`|
-| reset              | Discard all pending changes and restore the table to its last saved state after closing any active edit cell | `() => void`        |
-| tableData          | Current snapshot of all rows in the table (includes unsaved edits)         | `unknown[]`         |
+| Field               | Description                                                                                                  | Type                  |
+| :------------------ | :----------------------------------------------------------------------------------------------------------- | :-------------------- |
+| canUndo             | Whether there is at least one action that can be undone                                                      | `boolean`             |
+| canRedo             | Whether there is at least one action that can be redone                                                      | `boolean`             |
+| hasPendingChanges   | Whether there are unsaved cell edits, row additions, or deletions                                            | `boolean`             |
+| hasValidationErrors | Whether any cell currently has a validation error                                                            | `boolean`             |
+| canSave             | Whether saving is currently permitted — there are pending changes and every pending row passes `onValidate`  | `boolean`             |
+| undo                | Undo the last recorded action                                                                                | `() => void`          |
+| redo                | Redo the last undone action                                                                                  | `() => void`          |
+| save                | Commit all pending changes (calls `onUpdate` for each edited row) after closing any active edit cell         | `() => Promise<void>` |
+| reset               | Discard all pending changes and restore the table to its last saved state after closing any active edit cell | `() => void`          |
+| tableData           | Current snapshot of all rows in the table (includes unsaved edits)                                           | `unknown[]`           |
 
 </Box>
-

--- a/docs/src/componentDocs/DataTable/markdown/DataTableAPIDocs.mdx
+++ b/docs/src/componentDocs/DataTable/markdown/DataTableAPIDocs.mdx
@@ -18,7 +18,7 @@ The `<DataTable>` component is a fully-featured data table built on top of [mate
 | enableDuplicate       | Whether to allow duplicating rows                                                                              | `boolean`                                                         | no       | `false`           |
 | createDisplayMode     | How new rows are created — `'row'` (inline) or `'modal'`                                                       | `'row'` \| `'modal'`                                              | no       | `'row'`           |
 | editDisplayMode       | How rows are edited — `'cell'`, `'row'`, `'table'`, or `'modal'`                                               | `'cell'` \| `'row'` \| `'table'` \| `'modal'`                    | no       | `'cell'`          |
-| onValidate            | Called on every cell save; return an error map keyed by field name                                             | `(row: TData) => Partial<Record<keyof TData, string \| undefined>>` | no       |                   |
+| onValidate            | Called on cell save and when evaluating save eligibility; return an error map keyed by field name              | `(row: TData) => Partial<Record<keyof TData, string \| undefined>>` | no       |                   |
 | onCreate              | Called when a new row is saved                                                                                 | `(row: TData) => Promise<void> \| void`                           | no       |                   |
 | onUpdate              | Called for each edited row when changes are committed                                                          | `(row: TData) => Promise<void> \| void`                           | no       |                   |
 | onDelete              | Called when a row is deleted; receives the row's ID                                                            | `(id: string \| number) => Promise<void> \| void`                 | no       |                   |
@@ -38,7 +38,7 @@ The `<DataTable>` component is a fully-featured data table built on top of [mate
 | createButtonText      | Label for the bottom-toolbar create button                                                                     | `string`                                                          | no       | `'New data point'`|
 | deleteConfirmMessage  | Confirmation message (or factory function) shown before a row is deleted                                       | `string \| ((row: TData) => string)`                               | no       | `'Are you sure you want to delete this item?'` |
 | minHeight             | Minimum height of the table container                                                                          | `string \| number`                                                 | no       | `'109px'`         |
-| enableUndoRedo        | Enable undo/redo history with Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z keyboard shortcuts                               | `boolean`                                                         | no       | `false`           |
+| enableUndoRedo        | Enable undo/redo history with Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z (or Ctrl/Cmd+Y) keyboard shortcuts              | `boolean`                                                         | no       | `false`           |
 | onStateChange         | Called whenever state changes; receives an `DataTableState` snapshot for driving external controls         | `(state: DataTableState) => void`                              | no       |                   |
 
 </Box>
@@ -74,6 +74,8 @@ The `<DataTable>` component is a fully-featured data table built on top of [mate
 
 Passed to `onStateChange` on every relevant state change. Contains both reactive flags and stable action callbacks so a parent component can render its own toolbar outside the table.
 
+When `save` or `reset` is invoked, `DataTable` first closes any actively edited cell so the latest value is committed before the action runs.
+
 <Box>
 
 | Field              | Description                                                                 | Type                |
@@ -85,8 +87,8 @@ Passed to `onStateChange` on every relevant state change. Contains both reactive
 | canSave            | Whether saving is currently permitted — there are pending changes and every pending row passes `onValidate` | `boolean` |
 | undo               | Undo the last recorded action                                               | `() => void`        |
 | redo               | Redo the last undone action                                                 | `() => void`        |
-| save               | Commit all pending changes (calls `onUpdate` for each edited row)           | `() => Promise<void>`|
-| reset              | Discard all pending changes and restore the table to its last saved state   | `() => void`        |
+| save               | Commit all pending changes (calls `onUpdate` for each edited row) after closing any active edit cell | `() => Promise<void>`|
+| reset              | Discard all pending changes and restore the table to its last saved state after closing any active edit cell | `() => void`        |
 | tableData          | Current snapshot of all rows in the table (includes unsaved edits)         | `unknown[]`         |
 
 </Box>

--- a/docs/src/componentDocs/DataTable/markdown/DataTableAPIDocs.mdx
+++ b/docs/src/componentDocs/DataTable/markdown/DataTableAPIDocs.mdx
@@ -19,10 +19,10 @@ The `<DataTable>` component is a fully-featured data table built on top of [mate
 | createDisplayMode     | How new rows are created — `'row'` (inline) or `'modal'`                                                       | `'row'` \| `'modal'`                                              | no       | `'row'`           |
 | editDisplayMode       | How rows are edited — `'cell'`, `'row'`, `'table'`, or `'modal'`                                               | `'cell'` \| `'row'` \| `'table'` \| `'modal'`                    | no       | `'cell'`          |
 | onValidate            | Called on cell save and when evaluating save eligibility; return an error map keyed by field name              | `(row: TData) => Partial<Record<keyof TData, string \| undefined>>` | no       |                   |
-| onCreate              | Called when a new row is saved                                                                                 | `(row: TData) => Promise<void> \| void`                           | no       |                   |
+| onCreate              | Called when a new row is saved. The temporary internal ID is removed before this callback is invoked          | `(row: TData) => Promise<void> \| void`                           | no       |                   |
 | onUpdate              | Called for each edited row when changes are committed                                                          | `(row: TData) => Promise<void> \| void`                           | no       |                   |
-| onDelete              | Called when a row is deleted; receives the row's ID                                                            | `(id: string \| number) => Promise<void> \| void`                 | no       |                   |
-| onDuplicate           | Called when a row is duplicated                                                                                | `(row: TData) => Promise<void> \| void`                           | no       |                   |
+| onDelete              | Called when a persisted row is deleted; receives the row's ID. Unsaved new/duplicate rows are removed locally | `(id: string \| number) => Promise<void> \| void`                 | no       |                   |
+| onDuplicate           | Called when a duplicated row is saved. The temporary internal ID is removed before this callback is invoked   | `(row: TData) => Promise<void> \| void`                           | no       |                   |
 | getRowId              | Returns the unique ID for a row                                                                                | `(row: TData) => string`                                          | no       | `(row) => row.id` |
 | isLoading             | Show a loading overlay                                                                                         | `boolean`                                                         | no       | `false`           |
 | isSaving              | Show a saving overlay                                                                                          | `boolean`                                                         | no       | `false`           |
@@ -38,10 +38,17 @@ The `<DataTable>` component is a fully-featured data table built on top of [mate
 | createButtonText      | Label for the bottom-toolbar create button                                                                     | `string`                                                          | no       | `'New data point'`|
 | deleteConfirmMessage  | Confirmation message (or factory function) shown before a row is deleted                                       | `string \| ((row: TData) => string)`                               | no       | `'Are you sure you want to delete this item?'` |
 | minHeight             | Minimum height of the table container                                                                          | `string \| number`                                                 | no       | `'109px'`         |
-| enableUndoRedo        | Enable undo/redo history with Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z (or Ctrl/Cmd+Y) keyboard shortcuts              | `boolean`                                                         | no       | `false`           |
-| onStateChange         | Called whenever state changes; receives an `DataTableState` snapshot for driving external controls         | `(state: DataTableState) => void`                              | no       |                   |
+| enableUndoRedo        | Enable undo/redo history with Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z (or Ctrl/Cmd+Y). Tracks cell edits/add/delete/duplicate and clears on save/reset | `boolean`                                                         | no       | `false`           |
+| onStateChange         | Called whenever state changes; receives a `DataTableState` snapshot for driving external controls          | `(state: DataTableState) => void`                              | no       |                   |
 
 </Box>
+
+### Behavior Notes
+
+- Delete confirmation (`deleteConfirmMessage`) is only shown for persisted rows. Unsaved rows created in-session are removed immediately.
+- New and duplicated rows are tracked with internal temporary IDs until save. When `onCreate` / `onDuplicate` is called, that temporary `id` is stripped out.
+- Undo/redo history is capped internally and reset after an explicit save or reset, making the current committed state the new baseline.
+- In `editDisplayMode="row"` and `editDisplayMode="modal"`, MRT form-field props (for example `muiEditTextFieldProps`) are used. DataTable's custom cell editors are used in `cell` and `table` modes.
 
 ---
 

--- a/docs/src/componentDocs/DataTable/markdown/DataTableExamples.mdx
+++ b/docs/src/componentDocs/DataTable/markdown/DataTableExamples.mdx
@@ -21,6 +21,8 @@ Use `Cell` to render any React element in a cell (e.g. a progress bar). Use `cel
 
 ## External Toolbar with Save, Undo, Redo and Reset
 
-Use `enableUndoRedo` together with `onStateChange` to receive an `DataTableState` snapshot. Wire the stable callbacks (`undo`, `redo`, `save`, `reset`) and reactive flags (`canUndo`, `canRedo`, `hasPendingChanges`, `hasValidationErrors`) to your own toolbar controls placed anywhere in the page.
+Use `enableUndoRedo` together with `onStateChange` to receive an `DataTableState` snapshot. Wire the stable callbacks (`undo`, `redo`, `save`, `reset`) and reactive flags (`canUndo`, `canRedo`, `hasPendingChanges`, `hasValidationErrors`, `canSave`) to your own toolbar controls placed anywhere in the page.
+
+When `save` or `reset` is triggered from an external toolbar, `DataTable` first closes any actively edited cell so the latest in-progress value is committed before the action runs.
 
 <ExternalToolbarDataTable />

--- a/docs/src/componentDocs/DataTable/markdown/DataTableExamples.mdx
+++ b/docs/src/componentDocs/DataTable/markdown/DataTableExamples.mdx
@@ -11,6 +11,12 @@ The `<DataTable>` component provides inline cell editing with built-in validatio
 
 <BasicDataTable />
 
+## Row Editing Mode
+
+Use `editDisplayMode="row"` when you want full-row editing controls instead of single-cell editing. This mode is useful when edits should be reviewed and committed as a row-level action.
+
+<RowEditingDataTable />
+
 
 
 ## Custom Cells and Cell Styling
@@ -21,8 +27,13 @@ Use `Cell` to render any React element in a cell (e.g. a progress bar). Use `cel
 
 ## External Toolbar with Save, Undo, Redo and Reset
 
-Use `enableUndoRedo` together with `onStateChange` to receive an `DataTableState` snapshot. Wire the stable callbacks (`undo`, `redo`, `save`, `reset`) and reactive flags (`canUndo`, `canRedo`, `hasPendingChanges`, `hasValidationErrors`, `canSave`) to your own toolbar controls placed anywhere in the page.
+Use `enableUndoRedo` together with `onStateChange` to receive a `DataTableState` snapshot. Wire the stable callbacks (`undo`, `redo`, `save`, `reset`) and reactive flags (`canUndo`, `canRedo`, `hasPendingChanges`, `hasValidationErrors`, `canSave`) to your own toolbar controls placed anywhere in the page.
 
 When `save` or `reset` is triggered from an external toolbar, `DataTable` first closes any actively edited cell so the latest in-progress value is committed before the action runs.
+
+Notes shown in this example:
+- `canSave` may be `false` even when there are pending changes if validation fails on any pending row.
+- A newly added empty row does not make `canSave` true until at least one field is changed.
+- `Ctrl/Cmd+Z`, `Ctrl/Cmd+Shift+Z`, and `Ctrl/Cmd+Y` keyboard shortcuts are active when `enableUndoRedo` is enabled.
 
 <ExternalToolbarDataTable />

--- a/docs/src/componentDocs/DataTable/markdown/DataTableExamples.mdx
+++ b/docs/src/componentDocs/DataTable/markdown/DataTableExamples.mdx
@@ -1,15 +1,22 @@
 import {
     BasicDataTable,
+    ReadOnlyDataTable,
     RowEditingDataTable,
     CustomCellsDataTable,
     ExternalToolbarDataTable,
 } from '../examples';
 
-## Editable Table
+## Data Table 
 
 The `<DataTable>` component provides inline cell editing with built-in validation, CRUD operations, and an unsaved-change indicator (blue dot) per cell.
 
 <BasicDataTable />
+
+## Read-Only Mode
+
+Use `editable={false}` when you want the table in read-only mode. This is useful for dashboards and detail pages where users should be able to view data but not modify rows.
+
+<ReadOnlyDataTable />
 
 ## Row Editing Mode
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # . https://eaton-corp.atlassian.net/browse/BLUI-7250

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- updated example and api doc for editable table
 For Example page : 
- Added the missing Row Editing section and rendered the existing RowEditing example
- Added practical notes for external toolbar behavior :
canSave vs validation,
empty new row behavior,
keyboard shortcuts.
For API doc page : 
- Clarified that temporary internal ids are removed before onCreate/onDuplicate callbacks.
- Clarified onDelete behavior for persisted rows vs unsaved temp rows.
- Expanded enableUndoRedo description to include tracked actions and history clearing behavior.
- Added a Behavior Notes section documenting :
delete confirmation scope,
history reset semantics,
edit mode difference: cell/table vs row/modal editors.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- run dev docs and go to data table present in component section. check the example and api doc pages for same component.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [x] Code passes all linting checks
- [ ] All tests pass
- [ ] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [x] Documentation has been updated (if applicable)
- [ ] Changelog has been updated (if applicable)
